### PR TITLE
xlint: reject underscore in version

### DIFF
--- a/xlint
+++ b/xlint
@@ -246,7 +246,7 @@ for template; do
 	scan '[^\\]`' "use \$() instead of backticks"
 	scan '^pkgname="[^$]+"' "pkgname must not be quoted"
 	scan 'revision=0' "revision must not be zero"
-	scan '^version=.*[:-].*' "version must not contain the characters : or -"
+	scan '^version=.*[-:_].*' "version must not contain the characters - or : or _"
 	scan '^version=.*\${.*[:!#%/^,@].*}.*' "version must not use shell variable substitution mechanism"
 	scan '^version="[^$]+"' "version must not be quoted"
 	scan '^reverts=.*-.*' "reverts must not contain package name"


### PR DESCRIPTION
Is colon really forbidden? Not mentioned in manual, xbps-src processes colon in version, and it is already used in `telepathy-mission-control`.