### PR TITLE
xbulk: don't blindly strip the first line of show-build-deps

### DIFF
--- a/xbulk
+++ b/xbulk
@@ -25,7 +25,7 @@ done
 for pkg in $PKGS; do
 	echo all: pkg-$pkg
 	for dep in $(./xbps-src $ARGS show-build-deps $pkg |
-			sed 's|[<>].*$||g'); do
+			sed '/^[<=>]/d'); do
 		mainpkg $dep |
 		grep -Fx "$PKGS" |
 		sed 's/^/pkg-'$pkg': pkg-/'

--- a/xbulk
+++ b/xbulk
@@ -25,7 +25,7 @@ done
 for pkg in $PKGS; do
 	echo all: pkg-$pkg
 	for dep in $(./xbps-src $ARGS show-build-deps $pkg |
-			sed '1d;s|[<>].*$||g'); do
+			sed 's|[<>].*$||g'); do
 		mainpkg $dep |
 		grep -Fx "$PKGS" |
 		sed 's/^/pkg-'$pkg': pkg-/'


### PR DESCRIPTION
./xbp-src show-build-deps $pkg does start in the first line with returning dependencies, the current behaviour just stripped the first one