### PR TITLE
reorder xnew output

### DIFF
--- a/xlint
+++ b/xlint
@@ -29,7 +29,6 @@ variables_order() {
 			version=*) curr_index=3;;
 			revision=*) curr_index=4;;
 			archs=*) curr_index=5;;
-			revision=*) curr_index=6;;
 			wrksrc=*) curr_index=7;;
 			create_wrksrc=*) curr_index=8;;
 			build_wrksrc=*) curr_index=9;;

--- a/xnew
+++ b/xnew
@@ -36,9 +36,9 @@ cat >$srcdir/$PKG/template <<EOF
 pkgname=$PKG
 version=$version
 revision=1
+#archs="i686 x86_64"
 #wrksrc=
 #create_wrksrc=yes
-#archs="i686 x86_64"
 build_style=gnu-configure
 #configure_args=""
 #make_build_args=""


### PR DESCRIPTION
xlint want to have archs before wrksrc.
Sync xnew with xlint.