### PR TITLE
xlint: don't complain about public domain software

### DIFF
--- a/xlint
+++ b/xlint
@@ -258,7 +258,7 @@ for template; do
 	: ${LICENSE_LIST:=/usr/share/spdx/license.lst}
 	if [ -f "${LICENSE_LIST}" ]; then
 		sed -n 's/license="\(.*\)"/\1/p' "$template" | tr , "\n" | while read -r l; do
-			if echo "$l" | grep -q 'custom:'; then
+			if echo "$l" | grep -Eq 'custom:|Public Domain'; then
 				continue
 			fi
 


### PR DESCRIPTION
SPDX does not define an identifier for software that has been placed in
the public domain, as this does not define a license but rather the lack
of copyright protection or ownership.

Signed-off-by: Anthony Iliopoulos <ailiop@altatus.com>