### PR TITLE
xlint: check required-and-unique variables

### DIFF
--- a/xlint
+++ b/xlint
@@ -19,6 +19,15 @@ header() {
 	fi
 }
 
+exist_once() {
+	for var in pkgname version revision short_desc maintainer license \
+			homepage distfiles checksum; do
+		if [ $(grep -e "^${var}=" "$template" | wc -l) -ne 1 ]; then
+			echo "${template}: ${var} must be existed once"
+		fi
+	done
+}
+
 variables_order() {
 	local curr_index max_index max_index_line variables_end message line
 	max_index=0
@@ -237,6 +246,7 @@ xml_entries" | tr '\n' '|')
 ret=0
 for template; do
 	if [ -f "$template" ]; then
+	exist_once "$template"
 	scan 'short_desc=.*\."' "unwanted trailing dot in short_desc"
 	scan 'short_desc=["'\''][a-z]' "short_desc should start uppercase"
 	scan 'short_desc=["'\''](An?|The) ' "short_desc should not start with an article"


### PR DESCRIPTION
Some varibles must be existed or we can't package the software.
Moreover, the `version` variable must be existed once;
or `xlint` will report this weird error:

> grep: the -P option only supports a single pattern

Since `xlint` will feed this pattern to `grep`:

> grep -P -Hn -e "distfiles=.*\\Q3.0.2${newline}1\\E' $template

Usually, we won't see this because we expect people will use `xnew`.
However, some people haven't known about `xnew` or delete some line
accidentally. See:
https://www.reddit.com/r/voidlinux/comments/dkioss/issue_with_a_template_file/

Let's make a check for it.