### PR TITLE
set SOURCE_DATE_EPOCH to xbps-src template

### DIFF
--- a/xbump
+++ b/xbump
@@ -26,6 +26,11 @@ fi
 dirs="$dirs $(./xbps-src show "$pkg" |
 	sed -n '/^\(pkgname\|subpackage\)/s/[^:]*:[\t]*/srcpkgs\//p')"
 
+source_date=$(date -u +%s)
+
+sed -i -e "/^SOURCE_DATE_EPOCH=/s/=.*/=$source_date/" \
+	"$(xdistdir)/srcpkgs/$pkg/template"
+
 git add $dirs
 
 if git diff --quiet --cached --diff-filter=A -- srcpkgs/"$pkg"/template; then
@@ -34,4 +39,4 @@ else
 	msg="New package: $pkg-$version"
 fi
 
-git commit -m "$msg" "$@" $dirs
+GIT_AUTHOR_DATE="$source_date +0000" git commit -m "$msg" "$@" $dirs

--- a/xlint
+++ b/xlint
@@ -33,6 +33,11 @@ exists_once() {
 		   homepage; do
 		exists_once_for "$var"
 	done
+	if grep -Eq "^build_style=\(['\"]\?\)meta\1" "$template"; then
+		for var in distfiles checksum; do
+			exists_once_for "$var"
+		done
+	fi
 }
 
 variables_order() {

--- a/xlint
+++ b/xlint
@@ -34,7 +34,7 @@ exists_once() {
 		exists_once_for "$var"
 	done
 	if grep -Eq "^build_style=\(['\"]\?\)meta\1" "$template"; then
-		for var in distfiles checksum; do
+		for var in distfiles checksum SOURCE_DATE_EPOCH; do
 			exists_once_for "$var"
 		done
 	fi
@@ -157,6 +157,7 @@ OBJCOPY
 OBJDUMP
 RANLIB
 READELF
+SOURCE_DATE_EPOCH
 STRIP
 XBPS_FETCH_CMD
 allow_unknown_shlibs

--- a/xlint
+++ b/xlint
@@ -19,14 +19,19 @@ header() {
 	fi
 }
 
+exists_once_for() {
+	local var=$1
+	case "$(grep -c "^${var}=" "$template")" in
+		0) echo "$template: '$var' missing!";;
+		1) ;;
+		*) echo "$template: '$var' defined more than once";;
+	esac
+}
+
 exists_once() {
 	for var in pkgname version revision short_desc maintainer license \
 		   homepage; do
-		case "$(grep -c "^${var}=" "$template")" in
-			0) echo "$template: '$var' missing!";;
-			1) ;;
-			*) echo "$template: '$var' defined more than once";;
-		esac
+		exists_once_for "$var"
 	done
 }
 

--- a/xnew
+++ b/xnew
@@ -54,6 +54,7 @@ license="GPL-3.0-or-later"
 homepage="$homepage"
 distfiles="$distfiles"
 checksum=badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb
+SOURCE_DATE_EPOCH=$(date -u +%s)
 EOF
 
 for subpkg; do

--- a/xrevbump
+++ b/xrevbump
@@ -38,10 +38,15 @@ bump() {
 		;;
 	*)
 		revision=$((revision + 1))
+		source_date=$(date -u +%s)
 		printf "%s: bump to revision %d\n" "$t" "$revision"
 
-		sed -i -e "/^revision=/s/=.*/=$revision/" "$t"
-		git -C "${t%/*}" commit -m "$pkgname: $MESSAGE" template
+		sed -i -e "/^revision=/s/=.*/=$revision/" \
+			-e "/^SOURCE_DATE_EPOCH=/s/=.*/=$source_date" \
+			"$t"
+
+		GIT_AUTHOR_DATE="$source_date +0000" \
+			git -C "${t%/*}" commit -m "$pkgname: $MESSAGE" template
 		seen="$seen $pkgname "
 		;;
 	esac


### PR DESCRIPTION
From commit a4a229cf64, (xbps-src: use HEAD commit time for
SOURCE_DATE_EPOCH, 2018-03-08) of https://github.com/void-linux/void-packages
, we're using commit time of HEAD as SOURCE_DATE_EPOCH

Our distribution isn't reproducible anymore.
Because people will have a copy of our repository at some random time,
and they will build some random packages, those packages will be built
with the timestamp of the HEAD commit. But, our build bot will build
with the timestamp of another HEAD.

Let's take another route, ask people to put SOURCE_DATE_EPOCH directly
in the template, and uses that SOURCE_DATE_EPOCH instead.

This should work better even if minor details (maintainer,
hostmakedepends, etc...) changed.

Attach Unix timestamp instead of other time format (let's say ISO-8601),
because POSIX date doesn't provide portable option to convert them to
Unix timestamp.

---

Update xtools to support this change.
See https://github.com/void-linux/void-packages/pull/16756