### PR TITLE
xgensum: don't fore hostdir path if -H is omitted

### DIFF
--- a/xgensum
+++ b/xgensum
@@ -14,12 +14,10 @@ case "$1" in
 esac
 
 case "$1" in
-	-H*) FLAG_h=$2; shift; shift
+	-H*) FLAG_h="-H $2"; shift; shift
 esac
 
 XBPS_DISTDIR=$(xdistdir) || exit 1
-
-: ${FLAG_h:=$XBPS_DISTDIR/hostdir}
 
 if [ -f "$1" ]; then
 	template="$1"
@@ -39,7 +37,7 @@ if [ -f "${XBPS_DISTDIR}/common/environment/build-style/${build_style}.sh"  ]; t
 	. "${XBPS_DISTDIR}/common/environment/build-style/${build_style}.sh"
 fi
 
-XBPS_SRCDISTDIR=$("$XBPS_DISTDIR/xbps-src" -H $FLAG_h show-var XBPS_SRCDISTDIR | tail -1)
+XBPS_SRCDISTDIR=$("$XBPS_DISTDIR/xbps-src" $FLAG_h show-var XBPS_SRCDISTDIR | tail -1)
 srcdir="$XBPS_SRCDISTDIR/$pkgname-$version"
 
 if [ "$FLAG_f" = -f ]; then
@@ -49,10 +47,10 @@ if [ "$FLAG_f" = -f ]; then
 		distfile="$srcdir/$curfile"
 		rm -vf "$distfile"
 	done
-	"$XBPS_DISTDIR/xbps-src" -H $FLAG_h -I clean $pkgname
+	"$XBPS_DISTDIR/xbps-src" $FLAG_h -I clean $pkgname
 fi
 
-"$XBPS_DISTDIR/xbps-src" -H $FLAG_h -I fetch $pkgname
+"$XBPS_DISTDIR/xbps-src" $FLAG_h -I fetch $pkgname
 
 ret=0
 sums=""


### PR DESCRIPTION
This way, XBPS_HOSTDIR will be used by xbps-src just like XBPS_MASTERDIR.
`-H` can still overwrite it. It's kept for compatibility.