### PR TITLE
xlint: ignore comments

### DIFF
--- a/xlint
+++ b/xlint
@@ -6,6 +6,7 @@ export LC_ALL=C
 scan() {
 	local rx="$1" msg="$2"
 	grep -P -Hn -e "$rx" "$template" |
+		grep -v -P -e "[^:]*:[^:]*:\s*#" |
 		sed "s/^\([^:]*:[^:]*:\)\(.*\)/\1 $msg/"
 }
 


### PR DESCRIPTION
Makes scan ignore comments for they are always valid.

The first comment is still correctly validated,

see origin here: https://github.com/void-linux/void-packages/pull/20971