### PR TITLE
xlint: add check for unverified python_version

### DIFF
--- a/xlint
+++ b/xlint
@@ -330,6 +330,7 @@ for template; do
 	scan '^\t*[^ ]*  *\(\)' 'do not use space before function parenthesis'
 	scan '^\t*[^ ]*\(\)(|   *){' 'use one space after function parenthesis'
 	scan '^\t*[^ ]*\(\)$' 'do not use a newline before function opening brace'
+	scan 'python_version=.*#[[:space:]]*unverified' 'verify python_version and remove "#unverified"'
 	pkgname=$(grep -Po "^pkgname=\K.*" "$template")
 	version=$(grep -Po "^version=\K.*" "$template")
 	scan "distfiles=.*\Q$version\E" 'use ${version} in distfiles instead'


### PR DESCRIPTION
In `void-packages`, I am trying to drop the default `python_version` behavior and have explicitly added
```
python_version=2 #unverified
```
to packages which modify python shebangs but don't install modules in `/usr/lib/pythonX.Y` that would allow XBPS to determine the right python version. This PR adds an `xlint` rule to complain about the `#unverified` comment after `python_version` to flag packages that have been automatically tagged for `python2` but need to be properly checked to make sure that is the correct version.

[cf. `void-packages` PR#21209](https://github.com/void-linux/void-packages/pull/21209)