### PR TITLE
xlint: pycompile rules

### DIFF
--- a/xlint
+++ b/xlint
@@ -323,7 +323,6 @@ for template; do
 	scan 'distfiles=.*download.kde.org/stable' 'use $KDE_SITE'
 	scan 'distfiles=.*xorg\.freedesktop\.org/wiki/' 'use $XORG_HOME'
 	scan 'usr/lib/python3.[0-9]/site-packages' 'use $py3_sitelib'
-	grep -q "^pycompile_dirs=" "$template" ||
 	scan 'pycompile_module=' 'do not set pycompile_module, it is autodetected'
 	scan '^wrksrc=(\$\{[^}]+\}|[^${}/])*/.+' 'wrksrc should be a top-level directory'
 	scan '^\t*function\b' 'do not use the function keyword'

--- a/xlint
+++ b/xlint
@@ -221,7 +221,6 @@ preserve
 provides
 pycompile_dirs
 pycompile_module
-pycompile_version
 python_version
 register_shell
 replaces


### PR DESCRIPTION
pycompile_version is no more template variable.

pycompile_dirs and pycompile_module are independent, rule was introduced by misunderstanding.

cc @sgn