### PR TITLE
Distdir for all

### DIFF
--- a/xdbg
+++ b/xdbg
@@ -2,12 +2,19 @@
 # xdbg PKGS... - list debugging packages for PKGS and recursive dependencies
 
 BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
-ADDREPO="--repository=hostdir/binpkgs/$BRANCH
-	--repository=../hostdir/binpkgs/$BRANCH
-	--repository=../../hostdir/binpkgs/$BRANCH
-	--repository=hostdir/binpkgs
-	--repository=../hostdir/binpkgs
-	--repository=../../hostdir/binpkgs"
+XBPS_DISTDIR="$(xdistdir)" || XBPS_DISTDIR=.
+ADDREPO="
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/multilib
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/multilib/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/debug
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/multilib
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/multilib/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/debug
+"
 
 alldbg() {
 	xbps-query --regex $ADDREPO -Rs '-dbg-[^-]*$' |

--- a/xi
+++ b/xi
@@ -2,37 +2,18 @@
 # xi PKGS... - like xbps-install -S, but take cwd repo and sudo/su into account
 
 BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
+XBPS_DISTDIR="$(xdistdir)" || XBPS_DISTDIR=.
 ADDREPO="
-	--repository=hostdir/binpkgs/$BRANCH
-	--repository=../hostdir/binpkgs/$BRANCH
-	--repository=../../hostdir/binpkgs/$BRANCH
-	--repository=hostdir/binpkgs/$BRANCH/nonfree
-	--repository=../hostdir/binpkgs/$BRANCH/nonfree
-	--repository=../../hostdir/binpkgs/$BRANCH/nonfree
-	--repository=hostdir/binpkgs/$BRANCH/multilib
-	--repository=../hostdir/binpkgs/$BRANCH/multilib
-	--repository=../../hostdir/binpkgs/$BRANCH/multilib
-	--repository=hostdir/binpkgs/$BRANCH/multilib/nonfree
-	--repository=../hostdir/binpkgs/$BRANCH/multilib/nonfree
-	--repository=../../hostdir/binpkgs/$BRANCH/multilib/nonfree
-	--repository=hostdir/binpkgs/$BRANCH/debug
-	--repository=../hostdir/binpkgs/$BRANCH/debug
-	--repository=../../hostdir/binpkgs/$BRANCH/debug
-	--repository=hostdir/binpkgs
-	--repository=../hostdir/binpkgs
-	--repository=../../hostdir/binpkgs
-	--repository=hostdir/binpkgs/nonfree
-	--repository=../hostdir/binpkgs/nonfree
-	--repository=../../hostdir/binpkgs/nonfree
-	--repository=hostdir/binpkgs/multilib
-	--repository=../hostdir/binpkgs/multilib
-	--repository=../../hostdir/binpkgs/multilib
-	--repository=hostdir/binpkgs/multilib/nonfree
-	--repository=../hostdir/binpkgs/multilib/nonfree
-	--repository=../../hostdir/binpkgs/multilib/nonfree
-	--repository=hostdir/binpkgs/debug
-	--repository=../hostdir/binpkgs/debug
-	--repository=../../hostdir/binpkgs/debug
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/multilib
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/multilib/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/debug
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/multilib
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/multilib/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/debug
 "
 
 SUDO=

--- a/xls
+++ b/xls
@@ -2,12 +2,19 @@
 # xls PKGS... - list files contained in PKGS (including binpkgs)
 
 BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
-ADDREPO="--repository=hostdir/binpkgs/$BRANCH
-	--repository=../hostdir/binpkgs/$BRANCH
-	--repository=../../hostdir/binpkgs/$BRANCH
-	--repository=hostdir/binpkgs
-	--repository=../hostdir/binpkgs
-	--repository=../../hostdir/binpkgs"
+XBPS_DISTDIR="$(xdistdir)" || XBPS_DISTDIR=.
+ADDREPO="
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/multilib
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/multilib/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/debug
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/multilib
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/multilib/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/debug
+"
 
 for pkg; do
 	xbps-query $ADDREPO -f $pkg

--- a/xq
+++ b/xq
@@ -6,12 +6,19 @@ totop() {
 }
 
 BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
-ADDREPO="--repository=hostdir/binpkgs/$BRANCH
-	--repository=../hostdir/binpkgs/$BRANCH
-	--repository=../../hostdir/binpkgs/$BRANCH
-	--repository=hostdir/binpkgs
-	--repository=../hostdir/binpkgs
-	--repository=../../hostdir/binpkgs"
+XBPS_DISTDIR="$(xdistdir)" || XBPS_DISTDIR=.
+ADDREPO="
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/multilib
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/multilib/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/debug
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/multilib
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/multilib/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/debug
+"
 
 R=
 if [ "$1" = -R ]; then

--- a/xrs
+++ b/xrs
@@ -2,11 +2,18 @@
 # xrs PATTERN - like xbps-query -Rs, but take cwd repo into account
 
 BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
-ADDREPO="--repository=hostdir/binpkgs/$BRANCH
-	--repository=../hostdir/binpkgs/$BRANCH
-	--repository=../../hostdir/binpkgs/$BRANCH
-	--repository=hostdir/binpkgs
-	--repository=../hostdir/binpkgs
-	--repository=../../hostdir/binpkgs"
+XBPS_DISTDIR="$(xdistdir)" || XBPS_DISTDIR=.
+ADDREPO="
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/multilib
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/multilib/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/debug
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/multilib
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/multilib/nonfree
+	--repository=$XBPS_DISTDIR/hostdir/binpkgs/debug
+"
 
 xbps-query $ADDREPO -Rs "$@"


### PR DESCRIPTION
Use `xdistdir` to find out where `void-packages` is located, allowing for a smaller `ADDREPO` definition. The definition was then copied onto other utilities that make use of the local repositories, so everything operates on the same repos.