### PR TITLE
xlint: remove nonfree= check

### DIFF
--- a/xlint
+++ b/xlint
@@ -302,7 +302,6 @@ for template; do
 	scan 'homepage=.*\$' "homepage should not use variables"
 	scan 'maintainer=(?!.*<.*@.*>).*' "maintainer needs email address"
 	scan 'maintainer=.*<.*@users.noreply.github.com>.*' "maintainer needs a valid address for sending mail"
-	scan 'nonfree=' "use repository=nonfree"
 	scan '^(?!\s*('"$variables"'))[^\s=-]+=' \
 		"custom variables should use _ prefix: \2"
 	scan '^[^ =]*=(""|''|)$' "variable set to empty string: \2"


### PR DESCRIPTION
Fixes false positive on desc_option_nonfree=
The deprecated nonfree=yes was removed from all templates so this check
is not needed anymore