### PR TITLE
xdbg,xi,xlint,xls,xq,xrs: pipe xdistdir error to /dev/null.

### DIFF
--- a/xdbg
+++ b/xdbg
@@ -2,7 +2,7 @@
 # xdbg PKGS... - list debugging packages for PKGS and recursive dependencies
 
 BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
-XBPS_DISTDIR="$(xdistdir)" || XBPS_DISTDIR=.
+XBPS_DISTDIR="$(xdistdir 2>/dev/null)" || XBPS_DISTDIR=.
 ADDREPO="
 	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH
 	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/nonfree

--- a/xi
+++ b/xi
@@ -2,7 +2,7 @@
 # xi PKGS... - like xbps-install -S, but take cwd repo and sudo/su into account
 
 BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
-XBPS_DISTDIR="$(xdistdir)" || XBPS_DISTDIR=.
+XBPS_DISTDIR="$(xdistdir 2>/dev/null)" || XBPS_DISTDIR=.
 ADDREPO="
 	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH
 	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/nonfree

--- a/xlint
+++ b/xlint
@@ -247,7 +247,7 @@ wrksrc
 xml_catalogs
 xml_entries" | tr '\n' '|')
 
-void_packages="$(xdistdir)/"
+void_packages="$(xdistdir 2>/dev/null)/"
 ret=0
 for argument; do
 	template=

--- a/xls
+++ b/xls
@@ -2,7 +2,7 @@
 # xls PKGS... - list files contained in PKGS (including binpkgs)
 
 BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
-XBPS_DISTDIR="$(xdistdir)" || XBPS_DISTDIR=.
+XBPS_DISTDIR="$(xdistdir 2>/dev/null)" || XBPS_DISTDIR=.
 ADDREPO="
 	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH
 	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/nonfree

--- a/xq
+++ b/xq
@@ -6,7 +6,7 @@ totop() {
 }
 
 BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
-XBPS_DISTDIR="$(xdistdir)" || XBPS_DISTDIR=.
+XBPS_DISTDIR="$(xdistdir 2>/dev/null)" || XBPS_DISTDIR=.
 ADDREPO="
 	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH
 	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/nonfree

--- a/xrs
+++ b/xrs
@@ -2,7 +2,7 @@
 # xrs PATTERN - like xbps-query -Rs, but take cwd repo into account
 
 BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
-XBPS_DISTDIR="$(xdistdir)" || XBPS_DISTDIR=.
+XBPS_DISTDIR="$(xdistdir 2>/dev/null)" || XBPS_DISTDIR=.
 ADDREPO="
 	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH
 	--repository=$XBPS_DISTDIR/hostdir/binpkgs/$BRANCH/nonfree


### PR DESCRIPTION
Gah, sorry for this one D: 

They are outputting

```
xdistdir: can't find your void-packages tree, giving up
xdistdir: please export XBPS_DISTDIR=/path/to/void-packages
```

outside void-packages.