### PR TITLE
xlint: accept ignore_elf_dirs and ignore_elf_files

### DIFF
--- a/xlint
+++ b/xlint
@@ -184,6 +184,8 @@ go_package
 go_mod_mode
 homepage
 hostmakedepends
+ignore_elf_dirs
+ignore_elf_files
 keep_libtool_archives
 kernel_hooks_version
 lib32depends


### PR DESCRIPTION
They're introduced by e0979275b4 (11-pkglint-elf-in-usrshare: allow
explicit setting of exceptions, 2020-07-16)