### PR TITLE
xlint: version must not contain _

### DIFF
--- a/xlint
+++ b/xlint
@@ -304,7 +304,7 @@ for argument; do
 	scan '[^\\]`' "use \$() instead of backticks"
 	scan '^pkgname="[^$]+"' "pkgname must not be quoted"
 	scan 'revision=0' "revision must not be zero"
-	scan '^version=.*[:-].*' "version must not contain the characters : or -"
+	scan '^version=.*[:-_].*' "version must not contain the characters : - or _"
 	scan '^version=.*\${.*[:!#%/^,@].*}.*' "version must not use shell variable substitution mechanism"
 	scan '^version="[^$]+"' "version must not be quoted"
 	scan '^reverts=.*-.*' "reverts must not contain package name"


### PR DESCRIPTION
```
git/void-packages $ ./xbps-src -j12 pkg ...
=> ERROR: version contains invalid character: _
```
Makes sense, because of the revision.