### PR TITLE
Use environment variable $VISUAL instead of $EDITOR

### DIFF
--- a/xnew
+++ b/xnew
@@ -94,4 +94,4 @@ EOF
 	echo "}" >>$srcdir/$PKG/template
 done
 
-exec ${EDITOR:-vi} +3 $srcdir/$PKG/template
+exec ${VISUAL:-vi} +3 $srcdir/$PKG/template


### PR DESCRIPTION
`$VISUAL` is the environment variable for the visual (full-screen) editor, `$EDITOR` is for the line editor (see e.g. http://jdebp.uk./FGA/unix-editors-and-pagers.html). Git also gives priority to `$VISUAL` (see https://git-scm.com/docs/git-var).