### PR TITLE
xlint: improvements to lint from git index

### DIFF
--- a/README
+++ b/README
@@ -69,8 +69,10 @@ COMMANDS
      xlg pkg
         – open short commit log for XBPS template
 
-     xlint template | pkgname
+     xlint template | pkgname | :pkgname | :
         – scan XBPS template for common mistakes
+        - use ':pkgname' to lint template as staged in the git index
+        - use ':' to lint all templates staged in the git index
 
      xlocate
         [-g | -S | pattern] – locate files in all XBPS packages

--- a/xlint
+++ b/xlint
@@ -9,7 +9,7 @@ scan() {
 	local rx="$1" msg="$2"
 	grep -P -Hn -e "$rx" "$template" |
 		grep -v -P -e "[^:]*:[^:]*:\s*#" |
-		sed "s/^\([^:]*:[^:]*:\)\(.*\)/\1 $msg/"
+		sed "s/^[^:]*:\([^:]*\):\(.*\)/$argument:\1: $msg/"
 }
 
 once() {
@@ -349,19 +349,20 @@ void_packages="$(xdistdir 2>/dev/null)/"
 ret=0
 
 if [ "$1" = ":" ]; then
-    # get a list of all templates staged in the git index
+	# get a list of all templates staged in the git index
 	set -- $(git -C "$void_packages" diff --cached --name-only |
-        sed -ne 's|^srcpkgs/\([^/]*\)/template$|:\1|p')
+		sed -ne 's|^srcpkgs/\([^/]*\)/template$|:\1|p')
 fi
 
 for argument; do
 	template=
 	if [ -f "$argument" ]; then
 		template="$argument"
-    elif [ "${argument#:}" != "$argument" ]; then
+	elif [ "${argument#:}" != "$argument" ]; then
 		trap "rm -- ${tmpfile:=$(mktemp)}" EXIT INT TERM
-        git -C "$void_packages" show ":srcpkgs/${argument#:}/template" \
-            > ${template:=$tmpfile} || continue
+		# get template as staged in the git index
+		git -C "$void_packages" show ":srcpkgs/${argument#:}/template" \
+			> ${template:=$tmpfile} || continue
 	else
 		_template="${void_packages}srcpkgs/$argument/template"
 		[ -f "$_template" ] && template="$_template"
@@ -460,6 +461,6 @@ for argument; do
 	file_end
 	else
 	echo no such template "$argument" 1>&2
-	fi | sort -t: -n -k2 | grep . && ret=1
+	fi | sort -t: -n -k2 -k3 | grep . && ret=1
 done
 exit $ret

--- a/xtools.1
+++ b/xtools.1
@@ -73,8 +73,18 @@ but take cwd repo and sudo/su into account
 .Nd list installed packages by install-date
 .It Nm xlg Ar pkg
 .Nd open short commit log for XBPS template
-.It Nm xlint Ar template | pkgname
+.It Nm xlint Ar template | pkgname | Cm \&: Ns Ar pkgname | Cm \&:
 .Nd scan XBPS template for common mistakes
+.Bl -dash -offset 0n -width 0n -compact
+.It
+use
+.Sq Cm \&: Ns Ar pkgname
+to lint template as staged in the git index
+.It
+use
+.Sq Cm \&:
+to lint all templates staged in the git index
+.El
 .It Nm xlocate
 .Oo
 .Fl g | S |


### PR DESCRIPTION
 - do not leak $tmpfile in output from scan()
 - indent using tabs
 - add new options to README