### PR TITLE
xlint: fix bug in previous commit

### DIFF
--- a/xlint
+++ b/xlint
@@ -7,9 +7,12 @@ export LC_ALL=C
 
 scan() {
 	local rx="$1" msg="$2"
-	grep -P -Hn -e "$rx" "$template" |
-		grep -v -P -e "[^:]*:[^:]*:\s*#" |
-		sed "s/^[^:]*:\([^:]*\):\(.*\)/$argument:\1: $msg/"
+	grep -P -hn -e "$rx" "$template" |
+		grep -v -P -e "[^:]*:\s*#" |
+		sed "s/^\([^:]*\):\(.*\)/\1: $msg/" |
+		while read line; do
+			echo "$argument:$line"
+		done
 }
 
 once() {


### PR DESCRIPTION
In scan() I was using $argument in the sed script, but oftentimes
$arguments is a path including slashes which breaks havoc.

Different way now, hopefully this is correct now. Note that $msg has to
go through sed since some messages use `\2` to show the matching line.

@leahneukirchen: sorry I screwed this up, I hope everything works fine now!