### PR TITLE
New tool: xpkgdiff

### DIFF
--- a/_xtools
+++ b/_xtools
@@ -1,4 +1,4 @@
-#compdef xbuildbarf xbulk xbump xcheckrestart xdbg xdiff xdowngrade xgensum xgrep xi xilog xlg xlocate xlog xls xmypkgs xoptdiff xpkg xq xrecent xrevbump xrevshlib xsrc xsubpkg
+#compdef xbuildbarf xbulk xbump xcheckrestart xdbg xdiff xdowngrade xgensum xgrep xi xilog xlg xlocate xlog xls xmypkgs xoptdiff xpkg xpkgdiff xq xrecent xrevbump xrevshlib xsrc xsubpkg
 
 _xbps  # force autoload
 
@@ -98,6 +98,18 @@ _xpkg() {
 		'-V[show version numbers and description]'
 }
 
+_xpkgdiff() {
+	_arguments : \
+		'-S[compare package metadata]' \
+		'-c[compare a file from package]:file name:_files:package:_xbps_all_packages' \
+		'-f[compare package file lists]' \
+		'-p[compare package properties]' \
+		'-r[reverse diff (compare local to remote)]' \
+		'-x[compare package dependencies]' \
+		'-t[compare the full package dependency tree for -x]' \
+		'*:package:_xtools_just_packages'
+}
+
 _xq() {
 	_arguments : \
 		'-R[include remote information too]' \
@@ -136,6 +148,7 @@ _xtools() {
 		xmypkgs) _xmypkgs "$@";;
 		xoptdiff) _xoptdiff "$@";;
 		xpkg) _xpkg "$@";;
+		xpkgdiff) _xpkgdiff "$@";;
 		xq) _xq "$@";;
 		xrecent) _xtools_one_arch "$@";;
 		xrevbump) _xrevbump "$@";;

--- a/xpkgdiff
+++ b/xpkgdiff
@@ -1,0 +1,84 @@
+#!/bin/sh
+# xpkgdiff [-r] [-f|-x [-t]|-S|-c FILE|-p PROP[,...]] PKG - compare PKG between remote to local repositories
+
+usage() {
+	echo "Usage: xpkgdiff [-r] [-f|-x [-t]|-S|-c FILE|-p PROP[,...]] PKG"
+	exit 1
+}
+
+: ${DIFF:="diff -u --color"}
+
+# by default, don't sort
+SORT='cat'
+
+TMPDIR=$(mktemp --tmpdir -d "xpkgdiff.XXXXX")
+
+while getopts Sc:fhp:rtx flag; do
+	case $flag in
+		S) QUERY='--show' ;;
+		c) QUERY="--cat=$OPTARG" ;;
+		f) QUERY='--files'; SORT='sort' ;;
+		p) QUERY="--property $OPTARG" ;;
+		r) REVERSE=1 ;;
+		t) FULLTREE=1 ;;
+		x) QUERY='--deps'; SORT='sort' ;;
+		h|?) usage ;;
+	esac
+done
+
+shift $(($OPTIND - 1))
+
+[ "$#" -eq 0 ] && usage
+[ -z "$QUERY" ] && usage
+
+if [ "$QUERY" = '--deps' ] && [ -n "$FULLTREE" ]; then
+	QUERY='--fulldeptree --deps'
+fi
+
+BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
+if [ -n "$XBPS_HOSTDIR" ]; then
+	XBPS_BINPKGS="$XBPS_HOSTDIR/binpkgs"
+else
+	XBPS_DISTDIR="$(xdistdir 2>/dev/null)" || XBPS_DISTDIR=.
+	XBPS_BINPKGS="$XBPS_DISTDIR/hostdir/binpkgs"
+fi
+REPO="
+	--repository=$XBPS_BINPKGS/$BRANCH
+	--repository=$XBPS_BINPKGS/$BRANCH/nonfree
+	--repository=$XBPS_BINPKGS/$BRANCH/multilib
+	--repository=$XBPS_BINPKGS/$BRANCH/multilib/nonfree
+	--repository=$XBPS_BINPKGS/$BRANCH/debug
+	--repository=$XBPS_BINPKGS
+	--repository=$XBPS_BINPKGS/nonfree
+	--repository=$XBPS_BINPKGS/multilib
+	--repository=$XBPS_BINPKGS/multilib/nonfree
+	--repository=$XBPS_BINPKGS/debug
+"
+
+pkg="$1"
+
+if xbps-query $pkg >/dev/null; then
+	xbps-query -R $QUERY $pkg | $SORT > "$TMPDIR/${pkg}.repo"
+else
+	echo "Package '$pkg' not found in repositories" > "$TMPDIR/${pkg}.repo"
+fi
+# ignore-conf-repos here and not in the actual query
+# because --fulldeptree will probably fail without
+# being able to read from other repos
+if xbps-query --ignore-conf-repos $REPO $pkg >/dev/null; then
+	xbps-query $REPO $QUERY $pkg | $SORT > "$TMPDIR/${pkg}.local"
+else
+	echo "Package '$pkg' not found in local repositories" > "$TMPDIR/${pkg}.local"
+fi
+
+if [ -z "$REVERSE" ]; then
+	FILE1="${pkg}.repo"
+	FILE2="${pkg}.local"
+else
+	FILE1="${pkg}.local"
+	FILE2="${pkg}.repo"
+fi
+
+$DIFF $TMPDIR/$FILE1 $TMPDIR/$FILE2
+
+rm -rf $TMPDIR

--- a/xtools.1
+++ b/xtools.1
@@ -150,6 +150,30 @@ show version numbers
 .It Fl V
 show version numbers and description
 .El
+.It Nm xpkgdiff Op Fl Sfrxt Op Fl c Ar file Op Fl p Ar prop,... Ar pkg
+.Nd compare a package in the repositories to the locally-built version
+.Bl -dash -offset 0n -width 0n -compact
+.It
+run from within a void-packages checkout
+.It
+set DIFF to change the diff program used
+.El
+.Bl -tag -offset 2n -width 2n -compact
+.It Fl S
+compare package metadata
+.It Fl f
+compare package file lists
+.It Fl r
+reverse diff (compare local to remote)
+.It Fl x
+compare package dependencies
+.It Fl t
+compare the full package dependency tree. Only used with -x (equivalent to xbps-query --fulldeptree -x)
+.It Fl c Ar file
+compare a file from the package (equivalent to xbps-query --cat)
+.It Fl p Ar prop,...
+compare properties of the package
+.El
 .It Nm xpstree
 .Nd display tree view of xbps-src processes
 .It Nm xq Op Fl R Ar pkg ...


### PR DESCRIPTION
This adds a tool to diff a locally-built package with the equivalent in the repos.
It can compare files, file lists, dependency lists, and package metadata.

The diff program/arguments used can be set by setting the env var `DIFF`,
which allows users to use a diff program of their liking, like delta, meld, etc.

A tempdir is used to store the files to diff in the following format:

```
/tmp/xpkgdiff.XXXXX
    pkg.repo
    pkg.local
```

and is deleted when the script finishes.

Rendered manpage:
![image](https://user-images.githubusercontent.com/5366828/160082659-61bfb519-f376-42e8-b2e8-1ea63e783650.png)

<details><summary>example output</summary>

![image](https://user-images.githubusercontent.com/5366828/160082871-3045e11b-a7d6-4a75-875e-eb1b9a5889dc.png)
![image](https://user-images.githubusercontent.com/5366828/160083036-33c9970a-506e-4c40-a000-fe2ec9db0f88.png)
![image](https://user-images.githubusercontent.com/5366828/160083203-8439fa92-b05e-4652-a878-0c908adc2edd.png)

</details>