### PR TITLE
xpkgdiff: run an in-memory sync to allow use of XBPS_TARGET_ARCH

### DIFF
--- a/xpkgdiff
+++ b/xpkgdiff
@@ -57,8 +57,8 @@ REPO="
 
 pkg="$1"
 
-if xbps-query -R $pkg >/dev/null; then
-	xbps-query -R $QUERY $pkg | $SORT > "$TMPDIR/${pkg}.repo"
+if xbps-query -MR $pkg >/dev/null; then
+	xbps-query -MR $QUERY $pkg | $SORT > "$TMPDIR/${pkg}.repo"
 else
 	echo "Package '$pkg' not found in repositories" > "$TMPDIR/${pkg}.repo"
 fi


### PR DESCRIPTION
If the user would like to run a diff for a package on a certain arch, `XBPS_TARGET_ARCH=other-arch xpkgdiff -f foo` will now work properly, even if the user does not have a local repodata for that arch already.

This also allows xpkgdiff to work for all parts of the build matrix in void-packages' CI.
