### PR TITLE
xlint: deduplicate $pkgname and $version

### DIFF
--- a/xlint
+++ b/xlint
@@ -462,8 +462,8 @@ for argument; do
 	scan '^\t*[^ ]*\(\)(|   *){' 'use one space after function parenthesis'
 	scan '^\t*[^ ]*\(\)$' 'do not use a newline before function opening brace'
 	scan 'python_version=.*#[[:space:]]*unverified' 'verify python_version and remove "#unverified"'
-	pkgname=$(grep -Po "^pkgname=\K.*" "$template")
-	version=$(grep -Po "^version=\K.*" "$template")
+	pkgname=$(grep -Po "^pkgname=\K.*" "$template" | once)
+	version=$(grep -Po "^version=\K.*" "$template" | once)
 	scan "distfiles=.*\Q$version\E" 'use ${version} in distfiles instead'
 	scan "system_accounts=.*\b(?!($old_accounts))[a-zA-Z]" 'new accounts should be prefixed with underscore'
 	variables_order


### PR DESCRIPTION
This is a slightly naïve solution that does not check if `$pkgname` matches the template's directory. That would not be very trivial to do to work with the git index functionality or subpackages, and I'm not quite sure how to handle that.

Tested by putting two `$pkgname` and `$version` definitions in a template.

Before:
```
$ xlint chezmoi
grep: the -P option only supports a single pattern
chezmoi'
chezmoi: 'pkgname' defined more than once
chezmoi: 'version' defined more than once
chezmoi: Place license= after pkgname=
chezmoi: Place maintainer= after version=
chezmoi:1: Header should be: # Template file for 'chezmoi
chezmoi:4: revision does not appear immediately after version
```

After:
```
$ xlint chezmoi
chezmoi: 'pkgname' defined more than once
chezmoi: 'version' defined more than once
chezmoi: Place license= after pkgname=
chezmoi: Place maintainer= after version=
chezmoi:4: revision does not appear immediately after version
```
