### PR TITLE
xlint: check if manually defined wrksrc is default

### DIFF
--- a/xlint
+++ b/xlint
@@ -15,6 +15,10 @@ scan() {
 		done
 }
 
+regex_escape() {
+	sed 's/\([.*+]\)/\\\1/g'
+}
+
 once() {
 	head -n 1
 }
@@ -468,8 +472,11 @@ for argument; do
 	scan '^\t*[^ ]*\(\)$' 'do not use a newline before function opening brace'
 	scan 'python_version=.*#[[:space:]]*unverified' 'verify python_version and remove "#unverified"'
 	pkgname=$(grep -Po "^pkgname=\K.*" "$template" | once)
+	pkgname_re=$(echo "$pkgname" | regex_escape)
 	version=$(grep -Po "^version=\K.*" "$template" | once)
-	scan "distfiles=.*\Q$version\E" 'use ${version} in distfiles instead'
+	version_re=$(echo "$version" | regex_escape)
+	scan '^wrksrc="?(\$\{?pkgname\}?|'$pkgname_re')-(\$\{?version\}?|'$version_re')"?$' 'unnecessary wrksrc definition'
+	scan "distfiles=.*\Q$version_re\E" 'use ${version} in distfiles instead'
 	scan "system_accounts=.*\b(?!($old_accounts))[a-zA-Z]" 'new accounts should be prefixed with underscore'
 	variables_order
 	header


### PR DESCRIPTION
also adds a regex_escape filter to reduce false-positives in a couple places

this catches the following in the current void-packages tree:

```
srcpkgs/DataGrip/template: wrksrc="DataGrip-${version}"
srcpkgs/OpenLP/template: wrksrc="OpenLP-${version}"
srcpkgs/Trimage/template: wrksrc="Trimage-${version}"
srcpkgs/arduino/template: wrksrc=$pkgname-$version
srcpkgs/aws-cli/template: wrksrc="aws-cli-${version}"
srcpkgs/biber/template: wrksrc="${pkgname}-${version}"
srcpkgs/cargo/template: wrksrc="cargo-${version}"
srcpkgs/crack-attack/template: wrksrc="$pkgname-$version"
srcpkgs/db/template: wrksrc="db-${version}"
srcpkgs/gcdemu/template: wrksrc="gcdemu-${version}"
srcpkgs/glabels/template: wrksrc="glabels-${version}"
srcpkgs/gmime/template: wrksrc="gmime-${version}"
srcpkgs/gst-libav/template: wrksrc="${pkgname}-${version}"
srcpkgs/gufw/template: wrksrc="gufw-${version}"
srcpkgs/gwe/template: wrksrc="gwe-${version}"
srcpkgs/hugin/template: wrksrc="${pkgname}-${version}"
srcpkgs/lazydocker/template: wrksrc="lazydocker-${version}"
srcpkgs/libpano13/template: wrksrc="libpano13-${version}"
srcpkgs/logstalgia/template: wrksrc="$pkgname-$version"
srcpkgs/mailx/template: wrksrc="mailx-${version}"
srcpkgs/make-ca/template: wrksrc="make-ca-${version}"
srcpkgs/mandrel/template: wrksrc="mandrel-${version}"
srcpkgs/nodeenv/template: wrksrc="nodeenv-${version}"
srcpkgs/papi/template: wrksrc="papi-${version}"
srcpkgs/pdfpc/template: wrksrc="pdfpc-${version}"
srcpkgs/pex/template: wrksrc="pex-${version}"
srcpkgs/protobuf/template: wrksrc="protobuf-${version}"
srcpkgs/pyliblo/template: wrksrc="pyliblo-${version}"
srcpkgs/qolibri/template: wrksrc="${pkgname}-${version}"
srcpkgs/racket/template: wrksrc=${pkgname}-${version}
srcpkgs/rng-tools/template: wrksrc=${pkgname}-${version}
srcpkgs/rsClock/template: wrksrc="${pkgname}-${version}"
srcpkgs/sane-airscan/template: wrksrc="sane-airscan-${version}"
srcpkgs/scream/template: wrksrc=scream-$version
srcpkgs/simh/template: wrksrc="${pkgname}-${version}"
srcpkgs/tvheadend/template: wrksrc=tvheadend-${version}
srcpkgs/vegeta/template: wrksrc=${pkgname}-${version}
srcpkgs/xmldiff/template: wrksrc="xmldiff-${version}"
```
