### PR TITLE
xlint: escape slashes in scan() msg to prevent sed errors

### DIFF
--- a/xlint
+++ b/xlint
@@ -6,7 +6,7 @@
 export LC_ALL=C
 
 scan() {
-	local rx="$1" msg="$2"
+	local rx="$1" msg="$(echo $2 | sed 's,/,\\/,g')"
 	grep -P -hn -e "$rx" "$template" |
 		grep -v -P -e "[^:]*:\s*#" |
 		sed "s/^\([^:]*\):\(.*\)/\1: $msg/" |


### PR DESCRIPTION
tested using all templates with slashes in `$license`:

before:
```
$ xlint libtecla font-fontin libXaw3d linux-firmware hxtools ftjam libode clucene 
sed: -e expression #1, char 46: unknown option to `s'
sed: -e expression #1, char 60: unknown option to `s'
font-fontin: Place homepage= after maintainer=
font-fontin:8: short_desc should not start with an article
sed: -e expression #1, char 46: unknown option to `s'
/home/abi/void-packages/srcpkgs/libXaw3d/template:30: Last line is empty
sed: -e expression #1, char 47: unknown option to `s'
sed: -e expression #1, char 51: unknown option to `s'
sed: -e expression #1, char 51: unknown option to `s'
ftjam: Place nocross= after checksum=
sed: -e expression #1, char 40: unknown option to `s'
sed: -e expression #1, char 49: unknown option to `s'
sed: -e expression #1, char 50: unknown option to `s'
clucene: Place homepage= after maintainer=
```

after:
```
$ xlint libtecla font-fontin libXaw3d linux-firmware hxtools ftjam libode clucene
libtecla:10: use SPDX id for 'MIT/X11' license or see Manual.md
font-fontin:8: short_desc should not start with an article
font-fontin:9: Place homepage= after maintainer=
libXaw3d:12: use SPDX id for 'MIT/X11' license or see Manual.md
/home/abi/void-packages/srcpkgs/libXaw3d/template:30: Last line is empty
hxtools:10: use SPDX id for 'LGPL-2.1/LGPL-3.0' license or see Manual.md
ftjam:5: Place nocross= after checksum=
ftjam:10: use SPDX id for 'ftjam - /usr/share/licenses/ftjam/LICENSE' license or see Manual.md
libode:11: use SPDX id for 'LGPL-2/BSD' license or see Manual.md
libode:21: license LGPL-2/BSD should not be installed
clucene:13: Place homepage= after maintainer=
```

