### PR TITLE
xlint: remove print in explain_make_check

### DIFF
--- a/xlint
+++ b/xlint
@@ -38,7 +38,7 @@ exists_once() {
 
 explain_make_check() {
 	awk "-vtemplate=$template" -vOFS=: '
-		/make_check=[^#]*$/ && prev !~ /^[[:blank:]]*#/ {print(template, FNR, " explain why the tests fail"); print prev}
+		/make_check=[^#]*$/ && prev !~ /^[[:blank:]]*#/ {print(template, FNR, " explain why the tests fail")}
 		{prev=$0}
 	' $template
 }


### PR DESCRIPTION
tested all cases (no comment, comment on previous line, comment at end of line), all work.

before (prints line before make_check):
```
$ xlint R
shlib_provides="libR.so"
/home/abi/void-packages/srcpkgs/R/template:28: explain why the tests fail
```

after:
```
$ xlint R
/home/abi/void-packages/srcpkgs/R/template:28: explain why the tests fail
```
