### PR TITLE
xlint: lint multi-line value indentation

### DIFF
--- a/xlint
+++ b/xlint
@@ -47,6 +47,22 @@ explain_make_check() {
 	' $template
 }
 
+check_multiline_vars() {
+	for q in '"' "'"; do
+		awk "-vargument=$argument" "-vquote=$q" -vOFS=: '
+			BEGIN {
+				reBegin="^[^=]+=" quote "[^" quote "=]*$"; reEnd="^[^" quote "=]*" quote "$";
+				firstLine="^[^ ].*=" quote ".*$"; lastLine="^( [[:graph:]]|" quote "$)"
+			}
+			($0 ~ reBegin),($0 ~ reEnd) {
+				if ($0 !~ firstLine && $0 !~ lastLine)
+					print(argument, FNR, " indent multi-line continuations with a single space")
+				if ($0 ~ /\\$/)
+					print(argument, FNR, " do not use backslashes to end lines in multi-line continuations")
+			}' $template
+	done | sort -u -k2
+}
+
 variables_order() {
 	local curr_index max_index max_index_line variables_end message line
 	local line_number max_index_line_number
@@ -484,6 +500,7 @@ for argument; do
 	header
 	file_end
 	explain_make_check
+	check_multiline_vars
 	else
 	echo no such template "$argument" 1>&2
 	fi | sort -t: -n -k2 -k3 | grep . && ret=1


### PR DESCRIPTION
- use awk because scan (grep) does not work over multiple lines
- finds the opening and closing of a variable definition, then checks if it's on the first line and, if not, checks if the first characters are not <space><:graph:>
- checks both single- and double-quoted strings, in a loop because shell makes that hard
- detects lines in multi-line strings that end in a backslash
- `| sort -u -k2` so it does not spam, similar to the other indent lint
- This does sometimes overlap with the "please indent with tabs" and "bad indentation" lints. **Can that be solved somehow? Should it?**

tested by adding this to a template:
```bash
_foo="
 bar"

_yo="ahsjdfhsdfj
 fsdjhfsdjf"

_blah="asdfsf sdfjhsjhdf
    asjhdfjhsdfjhsdfjhd"

_bar="asdfhjsdfj
	sdjhfhsjdfhj"

_baz="asdfhjasdjhfsdj
 	asdjhfdjh"

_var="sjhdfhsdfh
asjfdsjhdfhjd"

_thing1="sdjfhsdfjsdf \
sdfjhsdjfsdf"

_thing2="sdjfhsdfjsdf \
 sdfjhsdjfsdf"
```

Result:
```
chezmoi:22: indent multi-line continuations with a single space
chezmoi:22: please indent with tabs
chezmoi:28: bad indentation: space before tabs
chezmoi:33: do not use backslashes to end lines in multi-line continuations
```

Without the `| sort -u -k2`, it would show lints on `_blah` (multiple spaces), `_bar` (tab), `_baz` (space then tab), `_var` (no leading whitespace), `_thing1`, and `_thing2`.

