### PR TITLE
xlint: require specifying versions when using cargo update

### DIFF
--- a/xlint
+++ b/xlint
@@ -479,6 +479,8 @@ for argument; do
 	scan '^wrksrc="?(\$\{?pkgname\}?|'$pkgname_re')-(\$\{?version\}?|'$version_re')"?$' 'unnecessary wrksrc definition'
 	scan "distfiles=.*\Q$version_re\E" 'use ${version} in distfiles instead'
 	scan "system_accounts=.*\b(?!($old_accounts))[a-zA-Z]" 'new accounts should be prefixed with underscore'
+	scan "cargo update (--package|-p) [A-Za-z_][A-Za-z0-9_]*(?!\:[0-9]+\.[0-9]+\.[0-9]+)(\s.+)?$" '"cargo update" commands should include the specific version we are updating from in the --package SPEC' 
+	scan "cargo update (--package|-p) [A-Za-z_][A-Za-z0-9_-]*\:[0-9]+\.[0-9]+\.[0-9]+(?!--precise [0-9]+\.[0-9]+\.[0-9]+)$" '"cargo update" commands should include the specific version we are updating to, using --precise' 
 	variables_order
 	header
 	file_end


### PR DESCRIPTION
The first of these two lints is to make sure that the version we try to update away from hasn't been updated by upstream in the mean time. For example in the `autocfg` case, some of the packages which have `cargo update --package autocfg --precise 1.1.0` included don't need that anymore, because the most recent release is already using 1.1.0 upstream. By specifying `cargo update --package autocfg:1.0.1 --precise 1.1.0`, cargo will complain if it can't find autocfg with version 1.0.1 in the current deps, meaning we'll see immediately when we don't need that line anymore. We currently have quite a few packages which don't specify a version here, which will get stale in the future. I don't want to know how many of these `cargo update -p openssl` we don't actually need anymore, but we don't commonly use this syntax yet, so it's not immediately apparent.

The second of these two lints is something that we're actually doing already, we're just telling people manually during reviews instead of having a lint for it: We explicitly tell cargo which version to update to.