### PR TITLE
xlint: fix lints broken by extra sed

### DIFF
--- a/xlint
+++ b/xlint
@@ -445,9 +445,8 @@ for argument; do
 	scan 'homepage=.*\$' "homepage should not use variables"
 	scan 'maintainer=(?!.*<.*@.*>).*' "maintainer needs email address"
 	scan 'maintainer=.*<.*@users.noreply.github.com>.*' "maintainer needs a valid address for sending mail"
-	scan '^(?!\s*('"$variables"'))[^\s=-]+=' \
-		"custom variables should use _ prefix: \2"
-	scan '^[^ =]*=(""|''|)$' "variable set to empty string: \2"
+	scan '^(?!\s*('"$variables"'))[^\s=-]+=' "custom variables should use _ prefix: \\\2"
+	scan '^[^ =]*=(""|''|)$' "variable set to empty string: \\\2"
 	scan '^(.*)-docs_package().*' 'use <pkgname>-doc subpackage for documentation'
 	scan 'distfiles=.*github.com.*/archive/.*\.zip[\"]?$' 'Use the distfile .tar.gz instead of .zip'
 	scan 'distfiles=.*downloads\.sourceforge\.net' 'use $SOURCEFORGE_SITE'


### PR DESCRIPTION
bug introduced in 8c0e21060fd0abdb16c10d62a56ead0a4da75062
