### PR TITLE
xchroot: do not require absolute path

### DIFF
--- a/xchroot
+++ b/xchroot
@@ -10,10 +10,7 @@ if [ "$(id -u)" -ne 0 ]; then
 	fail 'xchroot needs to run as root'
 fi
 
-case "$1" in
-	/*) CHROOT=$1; shift;;
-	*) fail 'no absolute chroot dir given';;
-esac
+CHROOT=$1; shift
 
 [ -d "$CHROOT" ] || fail 'not a directory'
 [ -d "$CHROOT/dev" ] || fail 'no /dev in chroot'


### PR DESCRIPTION
It seems to work with a relative path, so I am not sure why it requires an absolute path. This way it's much more user friendly.