### PR TITLE
xlint: check if vopt_if can be vopt_bool

### DIFF
--- a/xlint
+++ b/xlint
@@ -481,6 +481,7 @@ for argument; do
 	scan "system_accounts=.*\b(?!($old_accounts))[a-zA-Z]" 'new accounts should be prefixed with underscore'
 	scan "cargo update (--package|-p) [A-Za-z_][A-Za-z0-9_]*(?!\:[0-9]+\.[0-9]+\.[0-9]+)(\s.+)?$" '"cargo update" commands should include the specific version we are updating from in the --package SPEC' 
 	scan "cargo update (--package|-p) [A-Za-z_][A-Za-z0-9_-]*\:[0-9]+\.[0-9]+\.[0-9]+(?!--precise [0-9]+\.[0-9]+\.[0-9]+)$" '"cargo update" commands should include the specific version we are updating to, using --precise' 
+	scan '-D([[:alnum:]_-]+)=\$\(vopt_if \1 true false\)' 'use $(vopt_bool ...) instead of -D...=$(vopt_if ...)'
 	variables_order
 	header
 	file_end


### PR DESCRIPTION
fixes #257

seems to only happen once in current templates

```sh
$ fd template -tf srcpkgs | xargs -n1 xlint | grep vopt
srcpkgs/gsound/template:9: use $(vopt_bool ...) instead of -D...=$(vopt_if ...)
```
