### PR TITLE
xpkgdiff: improve cross functionality

### DIFF
--- a/_xtools
+++ b/_xtools
@@ -2,14 +2,15 @@
 
 _xbps  # force autoload
 
+_xtools_archs=( {aarch64,armv{6,7}l,i686,x86_64}{,-musl} )
+
 _xtools_all_packages() {
 	compadd "$@" -- $(xdistdir)/srcpkgs/*(:t)
 }
 
 _xtools_one_arch() {
-	local archs=( {aarch64,armv{6,7}l,i686,x86_64}{,-musl} )
 	_arguments : \
-		":architecture:($archs)"
+		":architecture:($_xtools_archs)"
 }
 
 _xtools_one_template() {
@@ -108,6 +109,7 @@ _xpkgdiff() {
 		'-r[reverse diff (compare local to remote)]' \
 		'-x[compare package dependencies]' \
 		'-t[compare the full package dependency tree for -x]' \
+		'-a[architecture]:architecture:('"$_xtools_archs"')' \
 		'*:package:_xtools_just_packages'
 }
 

--- a/xpkgdiff
+++ b/xpkgdiff
@@ -1,21 +1,23 @@
 #!/bin/sh
-# xpkgdiff [-r] [-f|-x [-t]|-S|-c FILE|-p PROP[,...]] PKG - compare PKG between remote to local repositories
+# xpkgdiff [-r] [-R URL] [-a ARCH] [-f|-x [-t]|-S|-c FILE|-p PROP[,...]] PKG - compare PKG between remote to local repositories
 
 usage() {
-	echo "Usage: xpkgdiff [-r] [-f|-x [-t]|-S|-c FILE|-p PROP[,...]] PKG"
+	echo "Usage: xpkgdiff [-r] [-R URL] [-a ARCH] [-f|-x [-t]|-S|-c FILE|-p PROP[,...]] PKG"
 	exit 1
 }
 
 cleanup() {
 	rm -rf $TMPDIR
+	exit 0
 }
 
 : ${DIFF:="diff -u --color"}
+: ${ARCH:=$XBPS_TARGET_ARCH}
 
 # by default, don't sort
 SORT='cat'
 
-while getopts Sc:fhp:rtx flag; do
+while getopts Sc:fhp:rtxa:R: flag; do
 	case $flag in
 		S) QUERY='--show' ;;
 		c) QUERY="--cat=$OPTARG" ;;
@@ -24,6 +26,8 @@ while getopts Sc:fhp:rtx flag; do
 		r) REVERSE=1 ;;
 		t) FULLTREE=1 ;;
 		x) QUERY='--deps'; SORT='sort' ;;
+		a) ARCH="$OPTARG" ;;
+		R) REMOTE_BASEURL="$OPTARG" ;;
 		h|?) usage ;;
 	esac
 done
@@ -32,6 +36,32 @@ shift $(($OPTIND - 1))
 
 [ "$#" -eq 0 ] && usage
 [ -z "$QUERY" ] && usage
+
+if [ -z "$ARCH" ]; then
+	# if arch is not set, just add the value of -R to the list
+	REMOTE_REPOS=" --repository=$REMOTE_BASEURL "
+else
+	[ "$ARCH" != "$XBPS_TARGET_ARCH" ] && export XBPS_TARGET_ARCH="$ARCH"
+	: ${REMOTE_BASEURL:="https://repo-default.voidlinux.org/current"}
+	case "$ARCH" in
+		aarch64*)
+			REMOTE_BASEURL=${REMOTE_BASEURL%/}/aarch64;;
+		*-musl)
+			REMOTE_BASEURL=${REMOTE_BASEURL%/}/musl;;
+		*)
+			REMOTE_BASEURL=${REMOTE_BASEURL%/};;
+	esac
+
+	# if arch is set, add all the standard repos for that arch, and ignore conf repos
+	REMOTE_REPOS="
+		-i
+		--repository=$REMOTE_BASEURL
+		--repository=$REMOTE_BASEURL/nonfree
+		--repository=$REMOTE_BASEURL/multilib
+		--repository=$REMOTE_BASEURL/multilib/nonfree
+		--repository=$REMOTE_BASEURL/debug
+	"
+fi
 
 TMPDIR=$(mktemp --tmpdir -d "xpkgdiff.XXXXX")
 
@@ -63,8 +93,8 @@ REPO="
 
 pkg="$1"
 
-if xbps-query -MR $pkg >/dev/null; then
-	xbps-query -MR $QUERY $pkg | $SORT > "$TMPDIR/${pkg}.repo"
+if xbps-query -MR $REMOTE_REPOS $pkg >/dev/null; then
+	xbps-query -MR $REMOTE_REPOS $QUERY $pkg | $SORT > "$TMPDIR/${pkg}.repo"
 else
 	echo "Package '$pkg' not found in repositories" > "$TMPDIR/${pkg}.repo"
 fi

--- a/xtools.1
+++ b/xtools.1
@@ -150,7 +150,7 @@ show version numbers
 .It Fl V
 show version numbers and description
 .El
-.It Nm xpkgdiff Op Fl Sfrxt Op Fl c Ar file Op Fl p Ar prop,... Ar pkg
+.It Nm xpkgdiff Op Fl Sfrxt Op Fl a Ar arch Op Fl R Ar url Op Fl c Ar file Op Fl p Ar prop,... Ar pkg
 .Nd compare a package in the repositories to the locally-built version
 .Bl -dash -offset 0n -width 0n -compact
 .It
@@ -173,6 +173,10 @@ compare the full package dependency tree. Only used with -x (equivalent to xbps-
 compare a file from the package (equivalent to xbps-query --cat)
 .It Fl p Ar prop,...
 compare properties of the package
+.It Fl a Ar arch
+set architecture for comparison
+.It Fl R Ar url
+set remote repository url
 .El
 .It Nm xpstree
 .Nd display tree view of xbps-src processes


### PR DESCRIPTION
adds `-R` and `-a` to make it easier to handle cross, but still support setting `XBPS_TARGET_ARCH` directly.
