### PR TITLE
xrevbump: various improvements

### DIFF
--- a/xrevbump
+++ b/xrevbump
@@ -1,19 +1,16 @@
 #!/bin/bash
-# xrevbump MESSAGE TEMPLATES... - increase template revision and commit
-
+# xrevbump MESSAGE TEMPLATES... -- git commit options - increase template revision and commit
 # TEMPLATES can be "-", then read linewise from stdin.
 
 MESSAGE=$1
 shift
 
 if [ $# -eq 0 ]; then
-	printf "Usage: xrevbump MESSAGE TEMPLATES...\n" 2>&1
+	printf "Usage: xrevbump MESSAGE TEMPLATES... -- git commit options\n" 2>&1
         exit 1
 fi
 
-seen=' '
-nl='
-'
+declare -a seen
 
 bump() {
 	t="$1"
@@ -32,29 +29,47 @@ bump() {
 
 	. "$t"
 
-	case "$seen" in
+	case "${seen[@]}" in
 	*" $pkgname "*)
 		printf "%s: bumped already.\n" "$t"
 		;;
 	*)
-		revision=$((revision + 1))
-		printf "%s: bump to revision %d\n" "$t" "$revision"
-
-		sed -i -e "/^revision=/s/=.*/=$revision/" "$t"
-		git -C "${t%/*}" commit -m "$pkgname: $MESSAGE" template
-		seen="$seen $pkgname "
+		if ! $(git diff HEAD "$t" | grep -q '^[-+]revision='); then
+			revision=$((revision + 1))
+			printf "%s: bump to revision %d\n" "$t" "$revision"
+			sed -i -e "/^revision=/s/=.*/=$revision/" "$t"
+		else
+			printf "%s: committing\n" "$t"
+		fi
+		git -C "${t%/*}" commit $commit_args -m "$pkgname: $MESSAGE" . || printf "\033[1;31m%s: failed to commit!\033[0m\n" "$t"
+		seen+=($pkgname)
 		;;
 	esac
 }
 
 XBPS_DISTDIR="$(xdistdir)"
 
+declare -a templates
+
 if [ "$1" = - ]; then
-	while IFS="$nl" read -r t; do
-		bump "$t"
-	done
+	shift
+	if [ "$1" =  -- ]; then
+		shift
+		commit_args="$@"
+	fi
+	IFS=$'\n' read -d '' -r -a templates
 else
 	for t; do
-		bump "$t"
+		if [ "$1" =  -- ]; then
+			shift
+			commit_args="$@"
+			break
+		fi
+		templates+=($t)
+		shift
 	done
 fi
+
+for t in "${templates[@]}"; do
+	bump "$t"
+done

--- a/xtools.1
+++ b/xtools.1
@@ -188,8 +188,10 @@ query remote repos
 .El
 .It Nm xrecent Op Ar repourl | arch
 .Nd list packages in repo ordered by build date
-.It Nm xrevbump Ar message Ar templates ...
-.Nd increase template revision and commit
+.It Nm xrevbump Ar message Ar templates ... Op Ar -- git commit options
+.Nd increase template revision and commit. Use
+.Sq Cm \&-
+to read templates from stdin.
 .It Nm xrevshlib Ar package
 .Nd list packages shlib-dependent on package or its subpackages
 .It Nm xrs Ar pattern


### PR DESCRIPTION
- commit all tracked files in srcpkgs/$pkgname/ instead of just template
- don't increment revision if the user has already done it
    - this also handles cases where committing fails, which now prints a message (two failure modes I have encountered: commit signing fails, pre-commit hook fails (I run `xlint` in one))
- allow addition of flags to the `git commit` invocation with `xrevbump MESSAGE TEMPLATES... -- COMMIT_ARGS`
- use more bashisms to make things a bit neater
- update manpage/usage
