### PR TITLE
xnew: don't use $pkgname in $distfiles

### DIFF
--- a/xnew
+++ b/xnew
@@ -31,7 +31,7 @@ case "$PKG" in
 	done
 	version=${version%.}
 	PKG=${PKG%-*}
-	distfiles="$homepage\${pkgname}-\${version}.$ext"
+	distfiles="$homepage$pkgname-\${version}.$ext"
 esac
 
 if [ -z "$append" ]; then


### PR DESCRIPTION
$pkgname is not constant, it can change when the package is renamed downstream while we would expect it to still build from the correct sources.

It also often doesn't save any characters and not using the variable makes prettier, simpler URLs that can often be copied from the template without manually replacing variables to get to the page with sources.

Closes #267 