### PR TITLE
xlint: Refuse quoted build_style

### DIFF
--- a/xlint
+++ b/xlint
@@ -448,6 +448,7 @@ for argument; do
 	scan '^reverts=.*-.*' "reverts must not contain package name"
 	scan '^reverts=(?!.*_.*).*' "reverts without revision"
 	scan 'archs=.?noarch.?' "noarch is deprecated and should no longer be used"
+	scan '^build_style="[^$]+"' "build_style must not be quoted"
 	scan 'replaces=(?=.*\w)[^<>]*$' "replaces needs depname with version"
 	scan 'homepage=.*\$' "homepage should not use variables"
 	scan 'maintainer=(?!.*<.*@.*>).*' "maintainer needs email address"


### PR DESCRIPTION
I'm wondering if this should be even more strict for some other variables as well.

So far only around 83 packages currently in void-packages will be affected by this change as per `xlint $(find srcpkgs -name template) | grep 'build_style must not be quoted'`:
<p><details>
<summary>Clock to show/hide the 83 package results</summary>
<pre><code>srcpkgs/xsel/template:5: build_style must not be quoted
srcpkgs/xfig/template:5: build_style must not be quoted
srcpkgs/xcalib/template:5: build_style must not be quoted
srcpkgs/wicd/template:6: build_style must not be quoted
srcpkgs/wavemon/template:5: build_style must not be quoted
srcpkgs/volta/template:6: build_style must not be quoted
srcpkgs/urxvtconfig/template:6: build_style must not be quoted
srcpkgs/tlpui/template:5: build_style must not be quoted
srcpkgs/texlive-science/template:5: build_style must not be quoted
srcpkgs/texlive-publishers/template:5: build_style must not be quoted
srcpkgs/texlive-pstricks/template:5: build_style must not be quoted
srcpkgs/texlive-pictures/template:5: build_style must not be quoted
srcpkgs/texlive-music/template:5: build_style must not be quoted
srcpkgs/texlive-latexextra/template:5: build_style must not be quoted
srcpkgs/texlive-langkorean/template:5: build_style must not be quoted
srcpkgs/texlive-langjapanese/template:5: build_style must not be quoted
srcpkgs/texlive-langgreek/template:5: build_style must not be quoted
srcpkgs/texlive-langextra/template:5: build_style must not be quoted
srcpkgs/texlive-langcyrillic/template:5: build_style must not be quoted
srcpkgs/texlive-langchinese/template:5: build_style must not be quoted
srcpkgs/texlive-humanities/template:5: build_style must not be quoted
srcpkgs/texlive-games/template:5: build_style must not be quoted
srcpkgs/texlive-formatsextra/template:5: build_style must not be quoted
srcpkgs/texlive-fontsextra/template:5: build_style must not be quoted
srcpkgs/texlive-core/template:5: build_style must not be quoted
srcpkgs/texlive-bibtexextra/template:5: build_style must not be quoted
srcpkgs/texi2html/template:5: build_style must not be quoted
srcpkgs/t1utils/template:5: build_style must not be quoted
srcpkgs/sway-audio-idle-inhibit/template:5: build_style must not be quoted
srcpkgs/sv-netmount/template:5: build_style must not be quoted
srcpkgs/sunxi-tools/template:6: build_style must not be quoted
srcpkgs/ssh-audit/template:5: build_style must not be quoted
srcpkgs/spt/template:10: build_style must not be quoted
srcpkgs/slurm/template:5: build_style must not be quoted
srcpkgs/sklogw/template:11: build_style must not be quoted
srcpkgs/scons/template:5: build_style must not be quoted
srcpkgs/sacc/template:5: build_style must not be quoted
srcpkgs/rust-bindgen/template:5: build_style must not be quoted
srcpkgs/runit/template:6: build_style must not be quoted
srcpkgs/rbw/template:6: build_style must not be quoted
srcpkgs/rbenv/template:5: build_style must not be quoted
srcpkgs/python3/template:8: build_style must not be quoted
srcpkgs/python3-tkinter/template:13: build_style must not be quoted
srcpkgs/python3-pyfiglet/template:5: build_style must not be quoted
srcpkgs/python3-poetry-core/template:5: build_style must not be quoted
srcpkgs/python3-neovim/template:5: build_style must not be quoted
srcpkgs/python3-musicbrainzngs/template:5: build_style must not be quoted
srcpkgs/python3-exifread/template:5: build_style must not be quoted
srcpkgs/python3-click/template:5: build_style must not be quoted
srcpkgs/python3-click-threading/template:5: build_style must not be quoted
srcpkgs/python3-click-log/template:5: build_style must not be quoted
srcpkgs/pymol/template:5: build_style must not be quoted
srcpkgs/perl-Locale-PO/template:5: build_style must not be quoted
srcpkgs/peframe/template:5: build_style must not be quoted
srcpkgs/openra/template:5: build_style must not be quoted
srcpkgs/ocs-url/template:6: build_style must not be quoted
srcpkgs/ocaml/template:5: build_style must not be quoted
srcpkgs/net-tools/template:5: build_style must not be quoted
srcpkgs/nasa-wallpaper/template:5: build_style must not be quoted
srcpkgs/mtr/template:5: build_style must not be quoted
srcpkgs/mirage/template:5: build_style must not be quoted
srcpkgs/mawk/template:6: build_style must not be quoted
srcpkgs/lrzip/template:5: build_style must not be quoted
srcpkgs/liquidwar/template:5: build_style must not be quoted
srcpkgs/linphone/template:5: build_style must not be quoted
srcpkgs/lilyterm/template:6: build_style must not be quoted
srcpkgs/lilypond/template:7: build_style must not be quoted
srcpkgs/liboggz/template:5: build_style must not be quoted
srcpkgs/libofx/template:5: build_style must not be quoted
srcpkgs/libfishsound/template:5: build_style must not be quoted
srcpkgs/haskell-language-server/template:5: build_style must not be quoted
srcpkgs/gtklp/template:5: build_style must not be quoted
srcpkgs/grml-rescueboot/template:6: build_style must not be quoted
srcpkgs/git-remote-hg/template:5: build_style must not be quoted
srcpkgs/gerbil/template:5: build_style must not be quoted
srcpkgs/geis/template:5: build_style must not be quoted
srcpkgs/filter_audio/template:9: build_style must not be quoted
srcpkgs/espeakup/template:5: build_style must not be quoted
srcpkgs/chrpath/template:5: build_style must not be quoted
srcpkgs/cc65/template:5: build_style must not be quoted
srcpkgs/blender/template:6: build_style must not be quoted
srcpkgs/ansible/template:5: build_style must not be quoted
srcpkgs/NetAuth/template:5: build_style must not be quoted</code></pre>
</details></p>