### PR TITLE
xchroot: mount and shell fixes

### DIFF
--- a/xchroot
+++ b/xchroot
@@ -17,21 +17,23 @@ CHROOT=$1; shift
 [ -d "$CHROOT/proc" ] || fail 'no /proc in chroot'
 [ -d "$CHROOT/sys" ] || fail 'no /sys in chroot'
 
-mount --rbind /dev "$CHROOT/dev"
-mount --rbind /proc "$CHROOT/proc"
-mount --rbind /sys "$CHROOT/sys"
+for _fs in dev proc sys; do
+	mount --rbind "/$_fs" "$CHROOT/$_fs"
+	mount --make-rslave "$CHROOT/$_fs"
+done
+
 touch "$CHROOT/etc/resolv.conf"
 mount --bind /etc/resolv.conf "$CHROOT/etc/resolv.conf"
 
 cleanup() {
-	umount -R "$CHROOT/dev" "$CHROOT/etc/resolv.conf" "$CHROOT/proc" "$CHROOT/sys"
+	umount -R "$CHROOT/dev" "$CHROOT/proc" "$CHROOT/sys" "$CHROOT/etc/resolv.conf"
 }
 
 trap cleanup EXIT INT
 
-if [ -f "$CHROOT/$SHELL" ]; then
+if [ -x "$CHROOT/$SHELL" ]; then
 	INNER_SHELL="$SHELL"
-elif [ -f "$CHROOT/bin/bash" ]; then
+elif [ -x "$CHROOT/bin/bash" ]; then
 	INNER_SHELL="/bin/bash"
 else
 	INNER_SHELL="/bin/sh"


### PR DESCRIPTION
- Only try to launch shells that are executable
- Make bind mounts slaves to avoid back-propagating unmounts

The latter point is especially important because, without `--make-rslave`, cleanup can fail trying back-propagate unmounts to the original `/dev` and `/sys` trees. If this is forced with a subsequent `umount -l`, it can wedge the host system because it will trigger an unmount of some key pseudo filesystems.