### PR TITLE
xchroot: propagate chroot(1)'s exit code

### DIFF
--- a/xchroot
+++ b/xchroot
@@ -41,8 +41,11 @@ fi
 
 printf "\033[1m=> Entering chroot $CHROOT\033[m\n"
 export PS1="[xchroot $CHROOT] $PS1"
-if chroot "$CHROOT" ${@:-$INNER_SHELL}; then
+chroot "$CHROOT" ${@:-$INNER_SHELL}
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
 	printf "\033[1m=> Exited chroot $CHROOT\033[m\n"
 else
-	printf "\033[1m=> Exited chroot $CHROOT with status $?\033[m\n"
+	printf "\033[1m=> Exited chroot $CHROOT with status $STATUS\033[m\n"
 fi
+exit $STATUS


### PR DESCRIPTION
Changes xchroot to exit with chroot(1)'s exit code on error.

As is, xchroot prints a warning when the actual chroot command failed, but
exits with 0.
