### PR TITLE
Update xmksv: change vlogger arg -f to -p

### DIFF
--- a/xmksv
+++ b/xmksv
@@ -20,7 +20,7 @@ for SRV; do
 		mkdir "$SRV/log"
 		cat <<EOF | install -m755 /dev/stdin "$SRV/log/run"
 #!/bin/sh
-exec vlogger -t $SRV -f daemon
+exec vlogger -t $SRV -p daemon
 EOF
 		if [ -w /run/runit ]; then
 			ln -s /run/runit/supervise."$(printf %s "$SRV/log" | tr / -)" \


### PR DESCRIPTION
man vlogger :

```
 -f file  Read lines from the specified file.  This option cannot be combine message arguments.
 -p pri   The.  pri can be facility.level or just facility.  See FACILITIES, LEVELS or syslog(3).  The default is “user.notice”.
```
`-p` is the correct arg. `-f` does not work