### PR TITLE
xlocate: add ability to pass certain flags to git grep

### DIFF
--- a/README
+++ b/README
@@ -78,12 +78,14 @@ COMMANDS
         - use ‘:pkgname’ to lint template as staged in the git index
         - use ‘:’ to lint all templates staged in the git index
 
-     xlocate -g | -S | pattern
+     xlocate -g | -S | [-EFGPiw] pattern
         – locate files in all XBPS packages
           -g  Update a git based xlocate database, useful for local
               repositories
           -S  Sync with the official git based xlocate database, which is
               recommended before using the tool
+          -E | -F | -G | -P | -i | -w
+              Modifies how pattern is matched. See git-grep(1) for more info
 
      xlog pkg
         – open commit log for XBPS template

--- a/xlocate
+++ b/xlocate
@@ -1,5 +1,5 @@
 #!/bin/sh
-# xlocate [-g | -S | PATTERN] - locate files in all XBPS packages
+# xlocate [-g | -S | [-EFGPiw] PATTERN] - locate files in all XBPS packages
 
 : ${XDG_CACHE_HOME:=~/.cache}
 : ${XDG_CONFIG_HOME:=~/.config}
@@ -68,17 +68,29 @@ xsyncgit() {
 	$GIT_CMD -C "$XLOCATE_GIT" fetch -u -f "$XLOCATE_REPO" master:master
 }
 
-case "$1" in
--g)
+usage() {
+	echo "Usage: xlocate [-g | -S | [-EFGPiw] PATTERN]" >&2
+}
+
+while getopts gSEFGPiwh flag; do
+	case $flag in
+		g) UPDATE=1 ;;
+		S) SYNC=1 ;;
+		[EFGPiw]) GREP_FLAGS="$GREP_FLAGS -$flag" ;;
+		h) usage; exit 0 ;;
+		?) usage; exit 1 ;;
+	esac
+done
+
+shift $(( OPTIND - 1 ))
+
+if [ -n "$UPDATE" ]; then
 	xupdategit
-	exit $?;;
--S)
+	exit $?
+elif [ -n "$SYNC" ]; then
 	xsyncgit
-	exit $?;;
-'')
-	echo "Usage: xlocate [-g | -S | PATTERN]" >&2
-	exit 1;;
-esac
+	exit $?
+fi
 
 if [ -d "$XLOCATE_GIT" ]; then
 	if [ -f "$XLOCATE_GIT/refs/heads/master" ]; then
@@ -93,7 +105,7 @@ if [ -d "$XLOCATE_GIT" ]; then
 			echo "xlocate: database outdated, please run xlocate -g." >&2
 		fi
 	fi
-	$GIT_CMD -c grep.lineNumber=false -c grep.column=false --git-dir="$XLOCATE_GIT" grep -- "$@" @ |
+	$GIT_CMD -c grep.lineNumber=false -c grep.column=false --git-dir="$XLOCATE_GIT" grep $GREP_FLAGS -- "$@" @ |
 		sed 's/^@://' | $COLUMN | grep .
 else
 	echo "xlocate: database not found, please use xlocate -S." >&2

--- a/xtools.1
+++ b/xtools.1
@@ -100,13 +100,19 @@ use
 .Sq Cm \&:
 to lint all templates staged in the git index
 .El
-.It Nm xlocate Fl g | Fl S | Ar pattern
+.It Nm xlocate Fl g | Fl S | Oo Fl EFGPiw Oc Ar pattern
 .Nd locate files in all XBPS packages
 .Bl -tag -offset 2n -width 2n -compact
 .It Fl g
 Update a git based xlocate database, useful for local repositories
 .It Fl S
 Sync with the official git based xlocate database, which is recommended before using the tool
+.It Fl E | Fl F | Fl G | Fl P | Fl i | Fl w
+Modifies how
+.Ar pattern
+is matched. See
+.Xr git-grep 1
+for more info
 .El
 .It Nm xlog Ar pkg
 .Nd open commit log for XBPS template


### PR DESCRIPTION
implemented what I thought would be useful and made sense, namely:

- `-E, --extended-regexp`
- `-F, --fixed-strings`
- `-G, --basic-regexp`
- `-P, --perl-regexp`
- `-i, --ignore-case`
- `-w, --word-regexp`

This will also allow for someone with `grep.patternType` or `grep.extendedRegexp` set in git's config to change the pattern type.

closes #197
fixes #175