### PR TITLE
xdiff : make sure $DIR is valid

### DIFF
--- a/xdiff
+++ b/xdiff
@@ -21,6 +21,11 @@ fi
 
 DIR=${1:-/etc}
 
+if ! [ -d "$DIR" ] ; then
+    echo "$DIR is not a valid directory" >&2
+    exit 1
+fi
+
 for newfile in $(find "$DIR" -name '*.new-*_*' | sort -V); do
 	$DIFF "$newfile" "${newfile%.new-*_*}"
 done


### PR DESCRIPTION
if user run `xdiff --help` , `--help` gets passed to find as an arg, it will cause infinite vimdiff instance coming out, has to kill xdiff's pid to stop it.