### PR TITLE
xchangelog improvements/fixes

### DIFF
--- a/_xtools
+++ b/_xtools
@@ -1,4 +1,4 @@
-#compdef xbuildbarf xbulk xbump xcheckrestart xdbg xdiff xdowngrade xgensum xgrep xi xilog xlg xlocate xlog xls xmypkgs xoptdiff xpkg xpkgdiff xq xrecent xrevbump xrevshlib xsrc xsubpkg
+#compdef xbuildbarf xbulk xbump xchangelog xcheckrestart xdbg xdiff xdowngrade xgensum xgrep xi xilog xlg xlocate xlog xls xmypkgs xoptdiff xpkg xpkgdiff xq xrecent xrevbump xrevshlib xsrc xsubpkg
 
 _xbps  # force autoload
 

--- a/xchangelog
+++ b/xchangelog
@@ -25,16 +25,16 @@ if [ -z "$changelog" ]; then
 fi
 
 if ! [ -t 1 ]; then
-	curl -s -- "$changelog"
-elif curl -sI -w "%{content_type}" -o /dev/null -- "$changelog" | grep -qi "^text/plain"; then
+	curl -sL -- "$changelog"
+elif curl -sLI -w "%{content_type}" -o /dev/null -- "$changelog" | grep -qi "^text/plain"; then
 	if [ -n "$PAGER" ]; then
-		curl -s -- "$changelog" | "$PAGER"
+		curl -sL -- "$changelog" | "$PAGER"
 	elif [[ "$changelog" = *".md" ]] && type mdless >/dev/null; then
-		curl -s -- "$changelog" | mdless
+		curl -sL -- "$changelog" | mdless
 	elif type less >/dev/null; then
-		curl -s -- "$changelog" | less
+		curl -sL -- "$changelog" | less
 	else
-		curl -s -- "$changelog"
+		curl -sL -- "$changelog"
 	fi
 else
 	if type xdg-open >/dev/null; then

--- a/xchangelog
+++ b/xchangelog
@@ -29,6 +29,8 @@ if ! [ -t 1 ]; then
 elif curl -sI -w "%{content_type}" -o /dev/null -- "$changelog" | grep -qi "^text/plain"; then
 	if [ -n "$PAGER" ]; then
 		curl -s -- "$changelog" | "$PAGER"
+	elif [[ "$changelog" = *".md" ]] && type mdless >/dev/null; then
+		curl -s -- "$changelog" | mdless
 	elif type less >/dev/null; then
 		curl -s -- "$changelog" | less
 	else


### PR DESCRIPTION
- use mdless to render markdown files if mdcat is installed
- xchangelog was missing from the `compdef` header
- use -L for curl to follow redirects


