### PR TITLE
xlint: lint crates.io distfile urls

### DIFF
--- a/xlint
+++ b/xlint
@@ -470,6 +470,7 @@ for argument; do
 	scan 'distfiles=.*freedesktop\.org/software' 'use $FREEDESKTOP_SITE'
 	scan 'distfiles=.*download.kde.org/stable' 'use $KDE_SITE'
 	scan 'distfiles=.*xorg\.freedesktop\.org/wiki/' 'use $XORG_HOME'
+	scan 'distfiles=.*crates.io/api/' 'use https://static.crates.io/crates/pkgname/pkgname-${version}.crate'
 	scan 'usr/lib/python3.[0-9]/site-packages' 'use $py3_sitelib'
 	scan 'pycompile_module=' 'do not set pycompile_module, it is autodetected'
 	scan '^\t*function\b' 'do not use the function keyword'


### PR DESCRIPTION
this is painful:
```
distfiles="https://crates.io/api/v1/crates/pkgname/${version}/download>pkgname-${version}.tar.gz"
```

this is better, and xbps-src already supports extracting them:
```
distfiles="https://static.crates.io/crates/pkgname/pkgname-${version}.crate"
```

this replaces void-linux/void-packages#43417 as it adding new `_SITE` variables has been discouraged
