### PR TITLE
new tool: xshellcheck

### DIFF
--- a/README
+++ b/README
@@ -169,6 +169,12 @@ COMMANDS
      xrs pattern
         – like xbps-query -Rs, but take cwd repo into account
 
+     xshellcheck template | pkgname | :pkgname | :
+        – scan XBPS template for common shell mistakes. Requires
+        shellcheck(1).
+        - use ‘:pkgname’ to lint template as staged in the git index
+        - use ‘:’ to lint all templates staged in the git index
+
      xsrc pkg
         – list source files for XBPS template
 

--- a/xshellcheck
+++ b/xshellcheck
@@ -1,0 +1,45 @@
+#!/bin/sh
+# xshellcheck TEMPLATE - scan XBPS template for shell scripting issues
+# xshellcheck :PKGNAME - shellcheck template as staged in the git index
+# xshellcheck :        - shellcheck all templates staged in the git index
+# use the env var XSHELLCHECK_ARGS to pass arguments to shellcheck
+
+if ! type shellcheck >/dev/null 2>&1; then
+	echo "xshellcheck: could not find shellcheck binary" >&2
+	echo "xshellcheck: is shellcheck installed?" >&2
+	exit 1
+fi
+
+void_packages="$(xdistdir 2>/dev/null)/"
+
+ret=0
+
+if [ "$1" = ":" ]; then
+	# get a list of all templates staged in the git index
+	set -- $(git -C "$void_packages" diff --cached --name-only |
+		sed -ne 's|^srcpkgs/\([^/]*\)/template$|:\1|p')
+fi
+
+for argument; do
+	template=
+	if [ -f "$argument" ]; then
+		template="$argument"
+	elif [ "${argument#:}" != "$argument" ]; then
+		argument="${argument#:}"
+		trap "rm -r -- ${tmpdir:=$(mktemp -d)}" EXIT INT TERM
+		# get template as staged in the git index
+		git -C "$void_packages" show ":srcpkgs/$argument/template" \
+			> ${template:=${tmpdir}/template} || continue
+	else
+		_template="${void_packages}srcpkgs/$argument/template"
+		[ -f "$_template" ] && template="$_template"
+	fi
+
+	if [ "$template" ]; then
+		shellcheck --norc -s bash \
+			-P "${template%/*}" \
+			$XSHELLCHECK_ARGS \
+			-xa "${void_packages}/common/scripts/template_shellcheck_shim" || ret="$?"
+	fi
+done | $filter
+exit $ret

--- a/xshellcheck
+++ b/xshellcheck
@@ -41,5 +41,5 @@ for argument; do
 			$XSHELLCHECK_ARGS \
 			-xa "${void_packages}/common/scripts/template_shellcheck_shim" || ret="$?"
 	fi
-done | $filter
+done
 exit $ret

--- a/xtools.1
+++ b/xtools.1
@@ -226,6 +226,20 @@ to read templates from stdin.
 .Nd list packages shlib-dependent on package or its subpackages
 .It Nm xrs Ar pattern
 .Nd like xbps-query -Rs, but take cwd repo into account
+.It Nm xshellcheck Ar template | pkgname | Cm \&: Ns Ar pkgname | Cm \&:
+.Nd scan XBPS template for common shell mistakes.
+Requires
+.Xr shellcheck 1 .
+.Bl -dash -offset 0n -width 0n -compact
+.It
+use
+.Sq Cm \&: Ns Ar pkgname
+to lint template as staged in the git index
+.It
+use
+.Sq Cm \&:
+to lint all templates staged in the git index
+.El
 .It Nm xsrc Ar pkg
 .Nd list source files for XBPS template
 .It Nm xsubpkg \


### PR DESCRIPTION
interface is similar to xlint

I don't intend on having xtools depend on shellcheck, because it is
nocross. users can install shellcheck on their own based on the error
message.

inspired by [apkbuild-lint-tools' apkbuild-shellcheck](https://gitlab.alpinelinux.org/alpine/infra/docker/apkbuild-lint-tools)

required for https://github.com/void-linux/void-packages/pull/43949

we may want to disable some warnings by default, currently these warnings are raised:

| count | code   | wiki link                              |
|------:|:-------|:---------------------------------------|
|  8516 | SC2086 | https://www.shellcheck.net/wiki/SC2086 |
|   499 | SC2034 | https://www.shellcheck.net/wiki/SC2034 |
|   287 | SC2016 | https://www.shellcheck.net/wiki/SC2016 |
|   156 | SC2091 | https://www.shellcheck.net/wiki/SC2091 |
|   144 | SC2046 | https://www.shellcheck.net/wiki/SC2046 |
|   103 | SC2035 | https://www.shellcheck.net/wiki/SC2035 |
|    83 | SC2154 | https://www.shellcheck.net/wiki/SC2154 |
|    75 | SC2209 | https://www.shellcheck.net/wiki/SC2209 |
|    73 | SC2231 | https://www.shellcheck.net/wiki/SC2231 |
|    59 | SC2155 | https://www.shellcheck.net/wiki/SC2155 |
|    53 | SC2044 | https://www.shellcheck.net/wiki/SC2044 |
|    39 | SC2295 | https://www.shellcheck.net/wiki/SC2295 |
|    36 | SC2115 | https://www.shellcheck.net/wiki/SC2115 |
|    28 | SC2166 | https://www.shellcheck.net/wiki/SC2166 |
|    22 | SC2185 | https://www.shellcheck.net/wiki/SC2185 |
|    21 | SC2103 | https://www.shellcheck.net/wiki/SC2103 |
|    19 | SC1091 | https://www.shellcheck.net/wiki/SC1091 |
|    13 | SC2043 | https://www.shellcheck.net/wiki/SC2043 |
|    12 | SC2162 | https://www.shellcheck.net/wiki/SC2162 |
|    12 | SC2001 | https://www.shellcheck.net/wiki/SC2001 |
|    10 | SC2129 | https://www.shellcheck.net/wiki/SC2129 |
|     9 | SC2098 | https://www.shellcheck.net/wiki/SC2098 |
|     9 | SC2038 | https://www.shellcheck.net/wiki/SC2038 |
|     7 | SC2031 | https://www.shellcheck.net/wiki/SC2031 |
|     6 | SC2090 | https://www.shellcheck.net/wiki/SC2090 |
|     6 | SC2013 | https://www.shellcheck.net/wiki/SC2013 |
|     5 | SC2140 | https://www.shellcheck.net/wiki/SC2140 |
|     5 | SC2097 | https://www.shellcheck.net/wiki/SC2097 |
|     5 | SC2045 | https://www.shellcheck.net/wiki/SC2045 |
|     4 | SC2261 | https://www.shellcheck.net/wiki/SC2261 |
|     4 | SC2153 | https://www.shellcheck.net/wiki/SC2153 |
|     4 | SC2015 | https://www.shellcheck.net/wiki/SC2015 |
|     3 | SC2269 | https://www.shellcheck.net/wiki/SC2269 |
|     3 | SC2223 | https://www.shellcheck.net/wiki/SC2223 |
|     3 | SC2196 | https://www.shellcheck.net/wiki/SC2196 |
|     3 | SC2089 | https://www.shellcheck.net/wiki/SC2089 |
|     3 | SC2061 | https://www.shellcheck.net/wiki/SC2061 |
|     3 | SC2059 | https://www.shellcheck.net/wiki/SC2059 |
|     3 | SC2030 | https://www.shellcheck.net/wiki/SC2030 |
|     3 | SC2004 | https://www.shellcheck.net/wiki/SC2004 |
|     3 | SC2002 | https://www.shellcheck.net/wiki/SC2002 |
|     2 | SC2237 | https://www.shellcheck.net/wiki/SC2237 |
|     2 | SC2125 | https://www.shellcheck.net/wiki/SC2125 |
|     2 | SC2094 | https://www.shellcheck.net/wiki/SC2094 |
|     2 | SC2005 | https://www.shellcheck.net/wiki/SC2005 |
|     1 | SC2222 | https://www.shellcheck.net/wiki/SC2222 |
|     1 | SC2221 | https://www.shellcheck.net/wiki/SC2221 |
|     1 | SC2207 | https://www.shellcheck.net/wiki/SC2207 |
|     1 | SC2168 | https://www.shellcheck.net/wiki/SC2168 |
|     1 | SC2145 | https://www.shellcheck.net/wiki/SC2145 |
|     1 | SC2144 | https://www.shellcheck.net/wiki/SC2144 |
|     1 | SC2102 | https://www.shellcheck.net/wiki/SC2102 |
|     1 | SC2100 | https://www.shellcheck.net/wiki/SC2100 |
|     1 | SC2078 | https://www.shellcheck.net/wiki/SC2078 |
|     1 | SC2068 | https://www.shellcheck.net/wiki/SC2068 |
|     1 | SC2012 | https://www.shellcheck.net/wiki/SC2012 |
|     1 | SC2010 | https://www.shellcheck.net/wiki/SC2010 |
|     1 | SC1090 | https://www.shellcheck.net/wiki/SC1090 |
