### PR TITLE
Clean up shell redirects

### DIFF
--- a/xbump
+++ b/xbump
@@ -16,7 +16,7 @@ spkpattern=$(xsubpkg "$pkg" | tr '\n' '|' | sed 's/\(.*\)|/^(\1)$/')
 shlibs=$(git diff common/shlibs | grep "^+[^+]" | \
 	sed "s/^+[^ ]\+ \(.*\)-[^-]\+_[0-9]\+$/\1/")
 if [ -n "$(echo "$shlibs" | grep -vE "$spkpattern")" ]; then
-	echo "common/shlibs contains uncommitted changes for other packages." 2>&1
+	echo "common/shlibs contains uncommitted changes for other packages." >&2
 	exit 1
 elif [ -n "$shlibs" ]; then
 	git add common/shlibs

--- a/xchroot
+++ b/xchroot
@@ -2,7 +2,7 @@
 # xchroot DIR [CMD...] - chroot into a Void (or other Linux) installation
 
 fail() {
-	printf '%s\n' "$1" 1>&2
+	printf '%s\n' "$1" >&2
 	exit 1
 }
 

--- a/xdistdir
+++ b/xdistdir
@@ -17,7 +17,7 @@ elif [ -d ~/src/void-packages ]; then
 elif [ -d ~/src/xbps-packages ]; then
 	echo ~/src/xbps-packages
 else
-	echo "xdistdir: can't find your void-packages tree, giving up" 1>&2
-	echo "xdistdir: please export XBPS_DISTDIR=/path/to/void-packages" 1>&2
+	echo "xdistdir: can't find your void-packages tree, giving up" >&2
+	echo "xdistdir: please export XBPS_DISTDIR=/path/to/void-packages" >&2
 	exit 111
 fi

--- a/xdowngrade
+++ b/xdowngrade
@@ -3,7 +3,7 @@
 
 for f; do
 	if ! [ -r "$f" ]; then
-		echo "$0: no such package: $f" 2>&1
+		echo "$0: no such package: $f" >&2
 		exit 2
 	fi
 done
@@ -12,7 +12,7 @@ ln -s -r -t "$T/" -- "$@"
 xbps-rindex -a $T/*
 n=$(xbps-query -i --repository="$T/" -L 2>/dev/null | awk '{print $1}')
 if [ -z "$n" ] || [ "$n" -ne "$#" ]; then
-	echo "$0: failed to register all $# packages." 2>&1
+	echo "$0: failed to register all $# packages." >&2
 	exit 2
 fi
 pkg=

--- a/xgensum
+++ b/xgensum
@@ -2,7 +2,7 @@
 # xgensum [-f] [-c] [-i] [-H hostdir] TEMPLATE - update SHA256 sums in templates
 
 usage() {
-	echo 'Usage: xgensum [-f] [-c] [-i] [-H hostdir] TEMPLATE' 1>&2
+	echo 'Usage: xgensum [-f] [-c] [-i] [-H hostdir] TEMPLATE' >&2
 	exit 1
 }
 

--- a/xlint
+++ b/xlint
@@ -492,7 +492,7 @@ for argument; do
 	file_end
 	explain_make_check
 	else
-	echo no such template "$argument" 1>&2
+	echo no such template "$argument" >&2
 	fi | sort -t: -n -k2 -k3 | grep . && ret=1
 done
 exit $ret

--- a/xlocate
+++ b/xlocate
@@ -17,7 +17,7 @@ if command -v git >/dev/null 2>&1; then
 elif command -v chroot-git >/dev/null 2>&1; then
 	GIT_CMD=$(command -v chroot-git)
 else
-	echo "xlocate: git command not found." 1>&2
+	echo "xlocate: git command not found." >&2
 	exit 1
 fi
 
@@ -76,7 +76,7 @@ case "$1" in
 	xsyncgit
 	exit $?;;
 '')
-	echo "Usage: xlocate [-g | -S | PATTERN]" 1>&2
+	echo "Usage: xlocate [-g | -S | PATTERN]" >&2
 	exit 1;;
 esac
 
@@ -88,14 +88,14 @@ if [ -d "$XLOCATE_GIT" ]; then
 	fi
 	if [ -z "$BASE" ] || find /var/db/xbps/ -name '*repodata' -newer "$BASE" | grep -q .; then
 		if grep -q origin "$XLOCATE_GIT/config"; then
-			echo "xlocate: database outdated, please run xlocate -S." 1>&2
+			echo "xlocate: database outdated, please run xlocate -S." >&2
 		else
-			echo "xlocate: database outdated, please run xlocate -g." 1>&2
+			echo "xlocate: database outdated, please run xlocate -g." >&2
 		fi
 	fi
 	$GIT_CMD -c grep.lineNumber=false -c grep.column=false --git-dir="$XLOCATE_GIT" grep -- "$@" @ |
 		sed 's/^@://' | $COLUMN | grep .
 else
-	echo "xlocate: database not found, please use xlocate -S." 1>&2
+	echo "xlocate: database not found, please use xlocate -S." >&2
 	exit 1
 fi

--- a/xmypkgs
+++ b/xmypkgs
@@ -4,7 +4,7 @@
 XDISTDIR="$(xdistdir)" || exit 1
 EMAIL=${1-$(git -C "$XDISTDIR" config user.email)}
 if [ -z "$EMAIL" ]; then
-	echo "who are you? tell your email address." 2>&1
+	echo "who are you? tell your email address." >&2
 	exit 1
 fi
 

--- a/xpcdeps
+++ b/xpcdeps
@@ -53,7 +53,7 @@ grab_local() {
 grab_requires() {
 	for pkg; do
 		xlocate "usr/\(lib\|share\)/pkgconfig/$pkg.pc" 2>/dev/null |
-		{ grep . || { echo "xpcdeps: No pkg-config file for $pkg found." 1>&2 ; exit 1; } } |
+		{ grep . || { echo "xpcdeps: No pkg-config file for $pkg found." >&2 ; exit 1; } } |
 		create_pcfile "$pkg"
 	done
 }
@@ -61,7 +61,7 @@ grab_requires() {
 get_package_from_requires() {
 	while read -r pkg ; do
 		xlocate "usr/\(lib\|share\)/pkgconfig/$pkg.pc" 2>/dev/null |
-		{ grep . || { printf -- "UNKNOWN PKG PLEASE FIX -> %s\\n" "$pkg" 1>&2 ; return; } } |
+		{ grep . || { printf -- "UNKNOWN PKG PLEASE FIX -> %s\\n" "$pkg" >&2 ; return; } } |
 		while read -r pkgname file ; do
 			file="${file##*/}"
 			printf "%s -> %s\\n" "${pkgname%-*}" "${file%*.pc}"

--- a/xpkg
+++ b/xpkg
@@ -27,7 +27,7 @@ while getopts R:r:vVmOHDLa flag; do
   -L       list installed packages not from remote repos
   -v       show version numbers
   -V       show version numbers and description
-" $0 1>&2
+" $0 >&2
 		exit 1;;
 	esac
 done

--- a/xrevbump
+++ b/xrevbump
@@ -6,7 +6,7 @@ MESSAGE=$1
 shift
 
 if [ $# -eq 0 ]; then
-	printf "Usage: xrevbump MESSAGE TEMPLATES... -- git commit options\n" 2>&1
+	printf "Usage: xrevbump MESSAGE TEMPLATES... -- git commit options\n" >&2
         exit 1
 fi
 

--- a/xvoidstrap
+++ b/xvoidstrap
@@ -4,7 +4,7 @@
 # (Setting XBPS_ARCH=x86_64-musl works.)
 
 fail() {
-	printf '%s\n' "$1" 1>&2
+	printf '%s\n' "$1" >&2
 	exit 1
 }
 


### PR DESCRIPTION
Some of these are outright wrong (e.g. `echo foo 2>&1`), others are just more verbose than they need to be.
