### PR TITLE
xbump: handle orphaning and adopting packages

### DIFF
--- a/xbump
+++ b/xbump
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash
 # xbump PKGNAME [git commit options] - git commit a new package or package update
 
 cd $(xdistdir)
@@ -29,7 +29,15 @@ dirs="$dirs $(./xbps-src show "$pkg" |
 git add $dirs
 
 if git diff --quiet --cached --diff-filter=A -- srcpkgs/"$pkg"/template; then
-	msg="$pkg: update to $version."
+	msg="$pkg: update to $version"
+	newmaintainer=$(git diff HEAD srcpkgs/"$pkg"/template | grep '+maintainer=' | \
+		cut -d '=' -f 2 | tr -d '"')
+	if [[ "$newmaintainer" = "Orphaned"* ]]; then
+		msg+=", orphan"
+	elif [ "$newmaintainer" ]; then
+		msg+=", adopt"
+	fi
+	msg+="."
 else
 	msg="New package: $pkg-$version"
 fi


### PR DESCRIPTION
xbump currently only handles updates or new packages, but no changes to the maintainership of the package.

With this change, xbump automatically appends `, adopt` to adopted packages and `, orphan` to newly orphaned packages with the changes to the template.

Using bash for that just makes the syntax easier to read, it could be left using sh though with some minor adjustments (as you prefer).