### PR TITLE
new tool: xnews

### DIFF
--- a/README
+++ b/README
@@ -105,6 +105,9 @@ COMMANDS
         – create XBPS template
           -a  append subpkgs to existing pkg
 
+     xnews [pattern]
+        – list news messages for packages by install-date
+
      xnodev
         – list not installed -devel packages for installed packages
 

--- a/xnews
+++ b/xnews
@@ -1,0 +1,14 @@
+#!/bin/sh
+# xnews [PATTERN] - list news messages for recently installed packages
+#
+if type less >/dev/null; then
+	: "${PAGER:=less}"
+else
+	: "${PAGER:=cat}"
+fi
+
+for pkg in $(xbps-query -p install-date -s '' |
+	sort -t: -k2 -r | cut -d: -f1 | grep -e "${1:-.}"); do
+	xbps-query -p install-msg "$pkg" |
+		awk -v pkg="$pkg" 'NR == 1 { print pkg ":" } { print "  " $0 }'
+done | $PAGER

--- a/xtools.1
+++ b/xtools.1
@@ -131,6 +131,8 @@ Op Ar subpkgs ...
 .It Fl a
 append subpkgs to existing pkg
 .El
+.It Nm xnews Op Ar pattern
+.Nd list news messages for packages by install-date
 .It Nm xnodev
 .Nd list not installed -devel packages for installed packages
 .It Nm xoptdiff \


### PR DESCRIPTION
employs a mechanism similar to xilog to get packages in installed order, then gets the install message for each in that order.

can be filtered by a pattern in the same method as xilog.

maybe there's a bit more efficient way to do this than a subshell + loop file i/o, but I don't see it

will be even more useful when install messages are only for actual news (https://github.com/void-linux/void-packages/pull/44273)

![image](https://github.com/leahneukirchen/xtools/assets/5366828/d8fe24c6-6b8f-475d-b006-2eeb32d89ab6)

