### PR TITLE
xlint: improve missing/multiply defined messages

### DIFF
--- a/xlint
+++ b/xlint
@@ -37,9 +37,12 @@ exists_once() {
 	for var in pkgname version revision short_desc maintainer license \
 		   homepage; do
 		case "$(grep -c "^${var}=" "$template")" in
-			0) echo "$argument: '$var' missing!";;
+			0) echo "$argument:1: '$var' missing!";;
 			1) ;;
-			*) echo "$argument: '$var' defined more than once";;
+			*)
+				lines="$(grep -n "^${var}=" "$template" | awk -F: 'NR>1 { printf ", " } { printf "%s", $1 }')"
+				echo "$argument:${lines##*, }: '$var' defined more than once: previously on line(s) ${lines%,*}"
+				;;
 		esac
 	done
 }


### PR DESCRIPTION
these are the only messages that don't have a line number associated with them, adding complexity when parsing the output of xlint.

- `'$var' missing!` only really makes sense with line number 1, as there is not really any other place to put it
- `'$var' defined more than once` I decided to put on the *last* instance of the variable, and add a hint to where the previous definition(s) are

```
$ xlint chezmoi
chezmoi:4: revision does not appear immediately after version
chezmoi:31: 'version' defined more than once: previously on line(s) 3, 25
```
