### PR TITLE
xvoidstrap: add ntpd etc to the install checklist.

### DIFF
--- a/xvoidstrap
+++ b/xvoidstrap
@@ -57,5 +57,6 @@ Void post-install checklist
 - Make dracut hostonly: echo hostonly=yes >/etc/dracut.conf.d/hostonly.conf
 - Rebuild initrd and grub config: xbps-reconfigure -f linux5.??
 - Enable default services: ln -s /etc/sv/... /etc/runit/runsvdir/default/
+- Install and enable an ntpd, and optionally cron and syslog.
 
 EOF


### PR DESCRIPTION
Add ntpd et all to the xvoidstrap checklist.

Walked some friends through a Void install, and we all forgot
about NTP because it wasn't on the very handy checklist.
