### PR TITLE
xlint: allow comments on version definition lines

### DIFF
--- a/xlint
+++ b/xlint
@@ -446,7 +446,7 @@ for argument; do
 	scan '[^\\]`' "use \$() instead of backticks"
 	scan '^pkgname="[^$]+"' "pkgname must not be quoted"
 	scan '^revision=0' "revision must not be zero"
-	scan '^version=.*[-:_].*' "version must not contain the characters - or : or _"
+	scan '^version=[^\n\r#]*[-:_].*' "version must not contain the characters - or : or _"
 	scan '^version=.*\${.*[:!#%/^,@].*}.*' "version must not use shell variable substitution mechanism"
 	scan '^version="[^$]+"' "version must not be quoted"
 	scan '^reverts=.*-.*' "reverts must not contain package name"


### PR DESCRIPTION
This is an oddly specific request that stems from my own CI setup. I use renovatebot to update packages in a private fork of void-packages. To simplify renovate's configuration, I write comments on the same line as the version number. Unfortunately this can trigger an xlint error in certain cases where it doesn't make sense, and this commit would fix that.

(The current implementation breaks one of my pipelines and I'm too lazy to patch the script in said pipelines, so I'm making an MR)