### PR TITLE
new tool: xdeptree

### DIFF
--- a/README
+++ b/README
@@ -16,7 +16,8 @@ COMMANDS
           -k  keep going on errors
 
      xbump pkgname [git commit options]
-        – git commit a new package or package update
+        – git commit a new package or package update. If pkgname is ‘:’, a
+        commit will be made for each template staged in the git index.
 
      xchangelog template | pkgname
         – open package changelog
@@ -37,6 +38,12 @@ COMMANDS
      xdbg pkgs ...
         – list debugging packages for pkgs and recursive dependencies
 
+     xdeptree [-L level] [-R] pkgname
+        – generate a tree of a package's dependencies
+          -L level
+              Max depth of tree
+          -R  Query remote repos
+
      xdiff [-u | -l] [basedir]
         – merge/diff/list XBPS .new-* files
           -l  list .new files
@@ -51,11 +58,13 @@ COMMANDS
      xetcchanges
         – show diff of /etc against binary packages
 
-     xgensum [-f] [-c] [-i] [-H hostdir] templates ...
+     xgensum [-f] [-c] [-i] [-a arch] [-H hostdir] templates ...
         – update SHA256 sum in templates
           -f  force (re-)download of distfiles
           -c  use content checksum
           -i  replace checksum in-place
+          -a  architecture to generate the checksum for (default: native or
+              first available architecture)
           -H  absolute path to hostdir
 
      xgrep pattern pkgs ...
@@ -180,6 +189,10 @@ COMMANDS
      xsubpkg [-m] pkg
         – list all subpackages of a package
           -m  only print main package
+
+     xtree pkg ...
+        – list files contained in pkg (including binpkgs) in a tree(1) -style
+        format.  If tree is not installed, falls back to xls.
 
      xuname
         – display system info relevant for debugging Void

--- a/xdeptree
+++ b/xdeptree
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+get_deps() {
+	local parents="$1" pkg="$2"
+	local -i lvl="$3"
+	local -a deps
+
+	parents="${parents:+$parents/}$pkg"
+
+	if (( MAXLVL > 0 && lvl >= MAXLVL )); then
+		echo "${parents}"
+		return
+	fi
+
+	if [ "${cache[$pkg]+_}" ]; then
+		read -r -a deps <<< "${cache[$pkg]}"
+	else
+		mapfile -t deps < <( xbps-query ${REPO:+$ADDREPO} -x "$pkg" | xargs -rn1 xbps-uhelper getpkgdepname )
+		cache[$pkg]="${deps[*]}"
+	fi
+
+	if [ "${#deps[@]}" -eq 0 ]; then
+		echo "${parents}"
+	fi
+
+	lvl=$(( lvl + 1 ))
+	for dep in "${deps[@]}"; do
+		get_deps "$parents" "$dep" "$lvl"
+	done
+}
+
+usage() {
+	echo "Usage: xdeptree [-L level] [-R] <pkgname>" >&2
+}
+
+
+BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
+if [ -n "$XBPS_HOSTDIR" ]; then
+	XBPS_BINPKGS="$XBPS_HOSTDIR/binpkgs"
+else
+	XBPS_DISTDIR="$(xdistdir 2>/dev/null)" || XBPS_DISTDIR=.
+	XBPS_BINPKGS="$XBPS_DISTDIR/hostdir/binpkgs"
+fi
+ADDREPO="
+	--repository=$XBPS_BINPKGS/$BRANCH
+	--repository=$XBPS_BINPKGS/$BRANCH/nonfree
+	--repository=$XBPS_BINPKGS/$BRANCH/multilib
+	--repository=$XBPS_BINPKGS/$BRANCH/multilib/nonfree
+	--repository=$XBPS_BINPKGS/$BRANCH/debug
+	--repository=$XBPS_BINPKGS
+	--repository=$XBPS_BINPKGS/nonfree
+	--repository=$XBPS_BINPKGS/multilib
+	--repository=$XBPS_BINPKGS/multilib/nonfree
+	--repository=$XBPS_BINPKGS/debug
+"
+
+declare -i MAXLVL=0
+REPO=''
+
+while getopts L:Rh flag; do
+	case "$flag" in
+		L)
+			if ! [[ "$OPTARG" =~ ^[0-9]+$ ]]; then
+				usage; exit 1
+			fi
+			MAXLVL="$OPTARG"
+			;;
+		R) REPO=1 ;;
+		h) usage; exit 0 ;;
+		?) usage; exit 1 ;;
+	esac
+done
+
+shift $(( OPTIND - 1 ))
+
+PKG="$1"
+
+if [ -z "$PKG" ]; then
+	usage
+	exit 1
+fi
+
+if ! command -v tree >/dev/null 2>&1; then
+	echo "missing tree(1) command"
+	exit 1
+fi
+
+declare -A cache=()
+
+get_deps '' "$PKG" 0 | sort -u | tree -n --noreport --fromfile .

--- a/xtools.1
+++ b/xtools.1
@@ -45,6 +45,14 @@ verbose mode, also print the library names
 .Nd detect file conflicts between XBPS packages
 .It Nm xdbg Ar pkgs ...
 .Nd list debugging packages for pkgs and recursive dependencies
+.It Nm xdeptree Oo Fl L Ar level Oc Oo Fl R Oc Ar pkgname
+.Nd generate a tree of a package's dependencies
+.Bl -tag -offset 2n -width 2n -compact
+.It Fl L Ar level
+Max depth of tree
+.It Fl R
+Query remote repos
+.El
 .It Nm xdiff \
 Oo Fl u | l Oc \
 Op Ar basedir


### PR DESCRIPTION
uses `tree(1)` to generate a true tree of a package's dependencies (unlike `xbps-query --fulldeptree -x`, which just generates a list from the tree)

### Examples

```
$ xdeptree chezmoi
.
└── chezmoi
    └── glibc
        └── libxcrypt-compat
```
limit the output depth:
```
$ xdeptree -L 3 -R python
.
└── python
    └── python2
        ├── bzip2
        │   └── glibc
        ├── ca-certificates
        │   ├── openssl
        │   └── run-parts
        ├── expat
        │   └── glibc
        ├── gdbm
        │   └── glibc
        ├── glibc
        │   └── libxcrypt-compat
        ├── libcrypto3
        │   └── glibc
        ├── libffi
        │   └── glibc
        ├── libreadline8
        │   ├── glibc
        │   └── ncurses-libs
        ├── libssl3
        │   └── glibc
        ├── libxcrypt
        │   └── glibc
        ├── ncurses-libs
        │   └── glibc
        ├── sqlite
        │   ├── glibc
        │   ├── libedit
        │   └── zlib
        └── zlib
            └── glibc
```
