### PR TITLE
xlint: add qmake_default_version variable

### DIFF
--- a/xlint
+++ b/xlint
@@ -97,6 +97,7 @@ variables_order() {
 			pycompile_dirs=*) curr_index=12;;
 			pycompile_module=*) curr_index=12;;
 			python_versions=*) curr_index=12;;
+			qmake_default_version=*) curr_index=12;;
 			scons_use_destdir=*) curr_index=12;;
 			stackage=*) curr_index=12;;
 			cabal_index_state=*) curr_index=12;;
@@ -262,6 +263,7 @@ pycompile_dirs
 pycompile_module
 python_extras
 python_version
+qmake_default_version
 register_shell
 replaces
 repository


### PR DESCRIPTION
`qmake_default_version` is used by the qmake build-helpers, but xlint does not recognize it.
Update xlint to handle this variable.

Related: https://github.com/void-linux/void-packages/pull/58378
